### PR TITLE
Refactor to use xstate internally for implementing statecharts

### DIFF
--- a/addon/utils/statechart.js
+++ b/addon/utils/statechart.js
@@ -1,148 +1,30 @@
 import { resolve } from 'rsvp';
+import { Machine } from 'xstate';
 
-class State {
+export default class Statechart {
   constructor(config) {
-    let { name, enterState, exitState, events, parent, context } = config;
+    this.machine = Machine(config);
 
-    this.parent     = parent;
-    this.name       = name;
-    this.enterState = enterState || function() {};
-    this.exitState  = exitState || function() {};
+    this.didChangeState = config.didChangeState || function() {};
+    this.context = config.context;
 
-    if (context) {
-      this.context = context;
-    }
-
-    let eventKeys = Object.keys(events || {});
-
-    this.events = eventKeys.reduce((acc, eventName) => {
-      acc[eventName] = events[eventName].bind(this);
-      return acc;
-    }, {});
+    this.currentState = this.machine.initialState;
   }
+  send(eventName, data = {}) {
+    let newState = this.machine.transition(this.currentState, { type: eventName, data }, this.context);
 
-  goToState(stateName, data) {
-    let newState = this.parent.states[stateName];
+    this.currentState = newState;
 
-    return resolve()
-      .then(() => this.exitState())
-      .then(() => {
-        this.parent.currentState = newState;
-      })
-      .then(() => {
-        this.parent.didChangeState(newState);
-      })
-      .then(() => newState.enterState(data));
-  }
+    let { actions } = newState;
 
-  eventByName(eventName) {
-    return this.events[eventName];
-  }
-}
+    this.didChangeState(newState);
 
-export default class StateChart {
-  constructor(config) {
-    let { initialState, states, context, didChangeState, name, events, parent, enterState, exitState } = config;
-
-    let stateNames = Object.keys(states);
-
-    let _states = stateNames.reduce((acc, stateName) => {
-      let stateConfiguration = states[stateName];
-      let stateConstructorParams = Object.assign(stateConfiguration, {
-        name: stateName,
-        parent: this,
-        context
+    let chain = actions.reduce((acc, action) => {
+      return acc.then(() => {
+        return action(data, this.context);
       });
+    }, resolve());
 
-      let state;
-
-      if (stateConfiguration.states) {
-        state = new StateChart(stateConstructorParams);
-      } else {
-        state = new State(stateConstructorParams);
-      }
-
-      acc[stateName] = state;
-
-      return acc;
-    }, {});
-
-    this.states = _states;
-    this.initialState = initialState;
-
-    if (name) {
-      this.name = name;
-    }
-
-    if (parent) {
-      this.parent = parent;
-    }
-
-    if (context) {
-      this.context = context;
-    }
-
-    this._enterState = enterState || function() {};
-    this._exitState  = exitState || function() {};
-
-    let eventKeys = Object.keys(events || {});
-
-    this.events = eventKeys.reduce((acc, eventName) => {
-      acc[eventName] = events[eventName].bind(this);
-      return acc;
-    }, {});
-
-    this.currentState = this.states[this.initialState];
-
-    this.didChangeState = didChangeState || function() {};
-  }
-
-  get name() {
-    return `${this._name}.${this.currentState.name}`;
-  }
-
-  set name(name) {
-    this._name = name;
-  }
-
-  enterState() {
-    this.currentState = this.states[this.initialState];
-
-    return resolve()
-      .then(() => this._enterState(...arguments))
-      .then(() => this.currentState.enterState(...arguments));
-  }
-
-  exitState() {
-    return resolve()
-      .then(() => this.currentState.exitState(...arguments))
-      .then(() => this._exitState(...arguments));
-  }
-
-  send(eventName, data) {
-    let eventHandler = this.currentState.eventByName(eventName);
-
-    if (eventHandler) {
-      return resolve()
-        .then(() => eventHandler(data));
-    }
-  }
-
-  eventByName(eventName) {
-    return this.currentState.eventByName(eventName) || this.events[eventName];
-  }
-
-  goToState(stateName, data) {
-    let newState = this.parent.states[stateName];
-
-    return resolve()
-      .then(() => this.exitState())
-      .then(() => {
-        this.parent.currentState = newState;
-      })
-      .then(() => {
-        this.parent.didChangeState(newState);
-      })
-      .then(() => newState.enterState(data));
+    return chain;
   }
 }

--- a/index.js
+++ b/index.js
@@ -1,5 +1,15 @@
 'use strict';
 
 module.exports = {
-  name: 'ember-statecharts'
+  name: 'ember-statecharts',
+
+  included(app) {
+    this._super.included.apply(this, arguments);
+
+    app.import('node_modules/xstate/dist/xstate.js', {
+      using: [
+        { transformation: 'amd', as: 'xstate' }
+      ]
+    });
+  }
 };

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "test:all": "ember try:each"
   },
   "dependencies": {
-    "ember-cli-babel": "^6.6.0"
+    "ember-cli-babel": "^6.6.0",
+    "xstate": "^3.2.1"
   },
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.5",

--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -1,0 +1,12 @@
+import Controller from '@ember/controller';
+import { Promise } from 'rsvp';
+
+export default Controller.extend({
+  actions: {
+    woot() {
+      return new Promise((resolve) => {
+        setTimeout(resolve, 2000);
+      });
+    }
+  }
+});

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,3 +1,5 @@
 <h2 id="title">Welcome to Ember</h2>
 
 {{outlet}}
+
+{{x-button text="lol" onClick=(action 'woot')}}

--- a/tests/unit/mixins/statechart-test.js
+++ b/tests/unit/mixins/statechart-test.js
@@ -12,21 +12,26 @@ module('Unit | Mixin | statechart', function() {
 
     let subject = StatechartObject.create({
       statechart: {
-        initialState: 'new',
+        initial: 'new',
         states: {
           new: {
-            exitState() {
+            onExit() {
               assert.ok(true, 'exitState was called');
             },
-            events: {
-              woot() {
-                assert.ok(true, 'event was called');
-                return this.goToState('foo', testData);
+            on: {
+              woot: {
+                foo: {
+                  actions: [
+                    () => {
+                      assert.ok(true, 'event was called');
+                    }
+                  ]
+                }
               }
             }
           },
           foo: {
-            enterState(data) {
+            onEntry(data) {
               assert.deepEqual(data, testData);
             }
           }
@@ -34,10 +39,10 @@ module('Unit | Mixin | statechart', function() {
       }
     });
 
-    assert.equal(get(subject, 'states.currentState.name'), 'new');
+    assert.equal(get(subject, 'states.currentState.value'), 'new');
 
-    await get(subject, 'states').send('woot');
+    await get(subject, 'states').send('woot', testData);
 
-    assert.equal(get(subject, 'states.currentState.name'), 'foo');
+    assert.equal(get(subject, 'states.currentState.value'), 'foo');
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -6117,6 +6117,10 @@ xmlhttprequest-ssl@~1.5.4:
   version "1.5.5"
   resolved "https://registry.yarnpkg.com/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.5.tgz#c2876b06168aadc40e57d97e81191ac8f4398b3e"
 
+xstate@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/xstate/-/xstate-3.2.1.tgz#b2206e78d8bbd32461fc2810f2d476dff049a80c"
+
 xtend@^4.0.0, xtend@~4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"


### PR DESCRIPTION
[xstate](https://github.com/davidkpiano/xstate) is a great library that can handle the heavy lifting for statecharts for us. 

This addon will now use xstate from now on to implement statecharts and only provide a small ember wrapper around it that holds the state of the chart.