### PR TITLE
Support passing strings in actions

### DIFF
--- a/addon/utils/statechart.js
+++ b/addon/utils/statechart.js
@@ -19,12 +19,21 @@ export default class Statechart {
 
     this.didChangeState(newState);
 
-    let chain = actions.reduce((acc, action) => {
+    let _actions = actions.map(this._functionForAction.bind(this));
+
+    let chain = _actions.reduce((acc, action) => {
       return acc.then(() => {
         return action(data, this.context);
       });
     }, resolve());
 
     return chain;
+  }
+  _functionForAction(action) {
+    if (typeof action === 'string') {
+      return (this.context && this.context[action] && this.context[action].bind(this.context)) || function() {};
+    }
+
+    return action;
   }
 }


### PR DESCRIPTION
xstate supports this so we want to support it as well.
We will execute a function on the statechart's context
that is called the same as the passed string. When no
function called like the passed string is found we will
execute a noop.