### PR TITLE
Allow strings in guard definitions

### DIFF
--- a/addon/mixins/statechart.js
+++ b/addon/mixins/statechart.js
@@ -1,10 +1,11 @@
 import Mixin from '@ember/object/mixin';
 import StateChart from '../utils/statechart';
 import { computed, get, set } from '@ember/object';
+import { makeArray } from '@ember/array';
 
 export default Mixin.create({
   states: computed('statechart', function() {
-    let statechart = get(this, 'statechart');
+    let [statechart, statechartOptions = {}] = makeArray(get(this, 'statechart'));
 
     let updateCurrentState = function(newState) {
       set(this, 'currentState', newState);
@@ -15,7 +16,7 @@ export default Mixin.create({
       didChangeState: updateCurrentState
     });
 
-    let _statechart = new StateChart(statechartConfiguration);
+    let _statechart = new StateChart(statechartConfiguration, statechartOptions);
 
     return _statechart;
   }),

--- a/addon/utils/statechart.js
+++ b/addon/utils/statechart.js
@@ -2,8 +2,8 @@ import { resolve } from 'rsvp';
 import { Machine } from 'xstate';
 
 export default class Statechart {
-  constructor(config) {
-    this.machine = Machine(config);
+  constructor(config, options) {
+    this.machine = Machine(config, options);
 
     this.didChangeState = config.didChangeState || function() {};
     this.context = config.context;

--- a/tests/unit/mixins/statechart-test.js
+++ b/tests/unit/mixins/statechart-test.js
@@ -1,4 +1,4 @@
-import EmberObject, { get } from '@ember/object';
+import EmberObject, { get, computed } from '@ember/object';
 import StatechartMixin from 'ember-statecharts/mixins/statechart';
 import { module, test } from 'qunit';
 
@@ -6,43 +6,92 @@ module('Unit | Mixin | statechart', function() {
   test('it adds statechart functionality to an ember-object', async function (assert) {
     assert.expect(5);
 
-    let StatechartObject = EmberObject.extend(StatechartMixin);
-
     let testData = { wat: 'lol' };
 
-    let subject = StatechartObject.create({
-      statechart: {
-        initial: 'new',
-        states: {
-          new: {
-            onExit() {
-              assert.ok(true, 'exitState was called');
-            },
-            on: {
-              woot: {
-                foo: {
-                  actions: [
-                    () => {
-                      assert.ok(true, 'event was called');
-                    }
-                  ]
+    let subject = EmberObject.extend(StatechartMixin, {
+      statechart: computed(function() {
+        return {
+          initial: 'new',
+          states: {
+            new: {
+              onExit() {
+                assert.ok(true, 'exitState was called');
+              },
+              on: {
+                woot: {
+                  foo: {
+                    actions: [
+                      () => {
+                        assert.ok(true, 'event was called');
+                      }
+                    ]
+                  }
                 }
               }
-            }
-          },
-          foo: {
-            onEntry(data) {
-              assert.deepEqual(data, testData);
+            },
+            foo: {
+              onEntry(data) {
+                assert.deepEqual(data, testData);
+              }
             }
           }
         }
-      }
-    });
+      })
+    }).create();
 
     assert.equal(get(subject, 'states.currentState.value'), 'new');
 
     await get(subject, 'states').send('woot', testData);
 
     assert.equal(get(subject, 'states.currentState.value'), 'foo');
+  });
+
+  test('it is possible to pass statechart-options to the statechart when passing an array of params', async function(assert) {
+    assert.expect(5);
+    let subject = EmberObject.extend(StatechartMixin, {
+      name: 'Tomster',
+
+      power: null,
+
+      statechart: computed(function() {
+        return [
+          {
+            initial: 'powerOff',
+            states: {
+              powerOff: {
+                on: {
+                  power: {
+                    powerOn: {
+                      cond: 'enoughPowerIsAvailable'
+                    }
+                  }
+                }
+              },
+              powerOn: {}
+            }
+          },
+          {
+            guards: {
+              enoughPowerIsAvailable: (context, { data  }) => {
+                assert.equal(context.name, 'Tomster', 'accessing context works');
+                let { power } = data;
+
+                return power > 9000;
+              }
+            }
+          }
+        ];
+      })
+    }).create();
+
+    assert.equal(get(subject, 'currentState.value'), 'powerOff', 'passing an array as a statechart property works');
+
+    await subject.get('states').send('power', { power: 1 });
+
+    assert.equal(get(subject, 'currentState.value'), 'powerOff', 'guards will not execute transition when a falsy value is returned');
+
+    await subject.get('states').send('power', { power: 9001 });
+
+    assert.equal(get(subject, 'currentState.value'), 'powerOn', 'returning a truthy from a guard executes the transition');
   });
 });


### PR DESCRIPTION
To cleanup guard definitions we now support string references for guards/conditions. To use this functionality users have to pass an options-object when creating the statechart property in addition to the statechart-configuration object. The statechart property was changed to support arrays to support this:

This allows reusing guard functions and cleaning up complex guard behaviour (although you most likely should not use complex guards anyway).

Example:

```js

import Componet from '@ember/component';
import Statechart from 'ember-statecharts/mixins/statechart';
import { computed } from '@ember/object';
export default Component.extend(Statechart, {
  statechart: computed(function() {
    return {
       initial: 'powerOff',
       states: {
         powerOn: {},
         powerOff: {
           on: {
             power: {
               powerOn: {
                 cond: (context, eventData) => {
                   return true;
                  } 
                }
             }
           }
         }
       }
    }
  })
}
```

Can be rewritten do:
```js

import Componet from '@ember/component';
import Statechart from 'ember-statecharts/mixins/statechart';
import { computed } from '@ember/object';
export default Component.extend(Statechart, {
      statechart: computed(function() {
        return [
          {
            initial: 'powerOff',
            states: {
              powerOff: {
                on: {
                  power: {
                    powerOn: {
                      cond: 'enoughPowerIsAvailable'
                    }
                  }
                }
              },
              powerOn: {}
            }
          },
          {
            guards: {
              enoughPowerIsAvailable: (context, { data  }) => {
                let { power } = data;

                return power > 9000;
              }
            }
          }
        ];
      })
}
```