### PR TITLE
Xstate 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,17 +94,33 @@ export default Component.extend({
         }
       },
       busy: {
-        onEntry: ['_handleClick'],
+        onEntry: ['executeOnClick'],
         on: {
           resolve: 'success',
           reject: 'error'
         }
       },
       success: {
-        onEntry: ['_handleSuccess'],
+        onEntry: ['handleSuccess'],
       },
       error: {
-        onEntry: ['_handleError'],
+        onEntry: ['handleError'],
+      }
+    }
+  }, {
+    actions: {
+      executeOnClick(/* data, context */) {
+        // `this` references the object that includes the statechart
+        return resolve()
+          .then(() => this.onClick())
+          .then(() => this.statechart.send('resolve'))
+          .catch(() => this.statechart.send('reject'))
+      },
+      handleSuccess() {
+        return this.onSuccess();
+      },
+      handleError() {
+        return this.onError();
       }
     }
   }),
@@ -117,21 +133,6 @@ export default Component.extend({
     } else {
       this.statechart.send('enable');
     }
-  },
-
-  _handleClick() {
-    return resolve()
-      .then(() => this.onClick())
-      .then(() => this.statechart.send('resolve'))
-      .catch(() => this.statechart.send('reject'))
-  },
-
-  _handleSuccess() {
-    return this.onSuccess();
-  },
-
-  _handleError() {
-    return this.onError();
   },
 
   click() {

--- a/addon/computed.js
+++ b/addon/computed.js
@@ -22,7 +22,11 @@ function debugState() {
 
 function statechart(statechartConfig, statechartOptions) {
   return computed(function() {
-    return new Statechart(assign(statechartConfig, { context: this }), statechartOptions);
+    const statechart = new Statechart(assign(statechartConfig, { context: this }), statechartOptions);
+
+    statechart.start();
+
+    return statechart;
   });
 }
 

--- a/addon/utils/statechart.js
+++ b/addon/utils/statechart.js
@@ -1,24 +1,130 @@
-import { resolve } from 'rsvp';
+import { Promise, resolve } from 'rsvp';
 import { Machine } from 'xstate';
 import { set } from '@ember/object';
+
+function noOp() {}
+
+class Interpreter {
+  constructor({ config, options, context}) {
+    this.machine = Machine(config, options);
+
+    this.currentState = this.machine.initialState;
+
+    this.context = context;
+  }
+
+  send(eventName, data) {
+    const newState = this.machine.transition(this.currentState, { type: eventName, data }, this.context);
+
+    this.currentState = newState;
+
+    let { actions } = newState;
+
+    let _actions = actions.map((action) => action.exec.bind(this.context));
+
+    let chain = _actions.reduce((acc, action) => {
+      return acc.then(() => {
+        return action(data);
+      });
+    }, resolve());
+
+    return chain;
+  }
+}
 
 export default class Statechart {
   constructor(config, options) {
     this.machine = Machine(config, options);
+    this.sendQueue = [];
 
-    this.didChangeState = config.didChangeState || function() {};
+    this.service = new Interpreter({
+      config: {
+        initial: 'initializing',
+        states: {
+          initializing: {
+            on: {
+              didInit: {
+                target: 'initialized',
+                actions: ['executeSendQueue']
+              },
+              send: {
+                target: 'initializing',
+                actions: ['enqueueSend']
+              }
+            }
+          },
+          initialized: {
+            on: {
+              send: {
+                target: 'initialized',
+                actions: ['executeSend']
+              }
+            }
+          }
+        }
+      },
+      options: {
+        actions: {
+          enqueueSend(sendData) {
+            this.sendQueue.push(sendData);
+            return this.initPromise;
+          },
+          executeSendQueue() {
+            let sends = this.sendQueue;
+            let chain = sends.reduce((acc, { eventName, data }) => {
+              return acc.then(() => {
+                return this.send(eventName, data)
+              });
+            }, resolve());
+
+            return chain
+              .then(() => {
+                this.resolveInit();
+              });
+          },
+          executeSend(sendData) {
+            return this._send(sendData);
+          },
+        }
+      },
+      context: this
+    })
+
+    this.didChangeState = config.didChangeState || noOp;
     this.context = config.context;
 
-    this.currentState = this.machine.initialState;
+    this.initPromise = new Promise((resolve, reject) => {
+      this.resolveInit = resolve;
+      this.rejectInit = reject;
+    });
   }
+
+  start() {
+    this.currentState = this.machine.initialState;
+
+    return this._executeActions(this.currentState)
+      .then(() => {
+        return this.service.send('didInit');
+      });
+  }
+
   send(eventName, data = {}) {
+    return this.service.send('send', { eventName, data });
+  }
+
+  _send({ eventName, data }) {
     let newState = this.machine.transition(this.currentState, { type: eventName, data }, this.context);
 
     set(this, 'currentState', newState);
 
-    let { actions } = newState;
-
     this.didChangeState(newState);
+
+    return this._executeActions(newState, data);
+
+  }
+
+  _executeActions(newState, data) {
+    let { actions } = newState;
 
     let _actions = actions.map(this._functionForAction.bind(this));
 
@@ -30,11 +136,9 @@ export default class Statechart {
 
     return chain;
   }
-  _functionForAction(action) {
-    if (typeof action === 'string') {
-      return (this.context && this.context[action] && this.context[action].bind(this.context)) || function() {};
-    }
 
-    return action;
+  _functionForAction(action) {
+    let fn = (action.exec && action.exec.bind(this.context)) || noOp;
+    return fn;
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "ember-auto-import": "^1.2.13",
     "ember-cli-babel": "^6.6.0",
-    "xstate": "^3.3.3"
+    "xstate": "^4.0.0"
   },
   "devDependencies": {
     "broccoli-asset-rev": "^2.7.0",

--- a/tests/dummy/app/components/x-button/component.js
+++ b/tests/dummy/app/components/x-button/component.js
@@ -37,13 +37,13 @@ export default Component.extend(Evented, {
         }
       },
       initialized: {
-        parallel: true,
+        type: 'parallel',
         states: {
           interactivity: {
             initial: 'unknown',
             states: {
               unknown: {
-                onEntry: ['_checkDisabled'],
+                onEntry: ['checkDisabled'],
                 on: {
                   disable: 'disabled'
                 }
@@ -61,22 +61,40 @@ export default Component.extend(Evented, {
                 },
               },
               busy: {
-                onEntry: ['_triggerAction'],
+                onEntry: ['triggerAction'],
                 on: {
                   success: 'success',
                   error: 'error'
                 }
               },
               success: {
-                onEntry: ['_triggerSuccess']
+                onEntry: ['triggerSuccess']
               },
               error: {
-                onEntry: ['_triggerError']
+                onEntry: ['triggerError']
               }
             }
           }
         }
       }
+    }
+  }, {
+    actions: {
+      checkDisabled() {
+        if (this.get('disabled')) {
+          this.get('statechart').send('disable');
+        }
+      },
+      triggerAction() {
+        this.get('onClickTask').perform();
+      },
+      triggerSuccess() {
+        this.get('onSuccess')();
+      },
+      triggerError() {
+        this.get('onError')();
+      }
+
     }
   }),
 
@@ -101,24 +119,6 @@ export default Component.extend(Evented, {
   handleOnClickError: on('onClickTask:errored', function() {
     this.get('statechart').send('error');
   }),
-
-  _triggerAction() {
-    this.get('onClickTask').perform()
-  },
-
-  _triggerSuccess() {
-    this.get('onSuccess')();
-  },
-
-  _triggerError() {
-    this.get('onError')();
-  },
-
-  _checkDisabled() {
-    if (this.get('disabled')) {
-      this.get('statechart').send('disable');
-    }
-  },
 
   click() {
     return get(this, 'statechart').send('click');

--- a/tests/unit/computed-test.js
+++ b/tests/unit/computed-test.js
@@ -99,13 +99,15 @@ module('Unit | statechart computeds', function(hooks) {
     test('can be used to log the current state of the statechart as a string', async function(assert) {
       let { subject } = this;
 
+      await subject.get('statechart').start();
+
       assert.deepEqual(subject.get('_debug'), '"playerOff"');
 
-      subject.get('statechart').send('power');
+      await subject.get('statechart').send('power');
 
       assert.deepEqual(subject.get('_debug'), JSON.stringify({ playerOn: 'stopped' }, 'works for nested states'));
 
-      subject.get('statechart').send('play');
+      await subject.get('statechart').send('play');
 
       assert.deepEqual(subject.get('_debug'), JSON.stringify({ playerOn: 'playing' }, 'updates when state is updated'));
     });

--- a/tests/unit/statechart-test.js
+++ b/tests/unit/statechart-test.js
@@ -16,13 +16,8 @@ module('Unit | computed | statechart', function() {
             },
             on: {
               woot: {
-                foo: {
-                  actions: [
-                    () => {
-                      assert.ok(true, 'event was called');
-                    }
-                  ]
-                }
+                target: 'foo',
+                actions: ['handleFoo']
               }
             }
           },
@@ -30,6 +25,12 @@ module('Unit | computed | statechart', function() {
             onEntry(data) {
               assert.deepEqual(data, testData);
             }
+          }
+        }
+      }, {
+        actions: {
+          handleFoo() {
+            assert.ok(true, 'event was called');
           }
         }
       }),
@@ -61,9 +62,8 @@ module('Unit | computed | statechart', function() {
             powerOff: {
               on: {
                 power: {
-                  powerOn: {
-                    cond: 'enoughPowerIsAvailable'
-                  }
+                  target: 'powerOn',
+                  cond: 'enoughPowerIsAvailable'
                 }
               }
             },

--- a/tests/unit/utils/statechart-test.js
+++ b/tests/unit/utils/statechart-test.js
@@ -1,260 +1,439 @@
 import Statechart from 'dummy/utils/statechart';
 import { module, test } from 'qunit';
+import { Promise } from 'rsvp';
 
 module('Unit | Utility | statechart', function(/*hooks*/) {
 
-  test('it starts with an initial state', function(assert) {
-    let result = new Statechart({
-      initial: 'new',
-      states: {
-        new: {}
-      }
+  module('#start', function() {
+    test('it has a currentState after starting', function(assert) {
+      let result = new Statechart({
+        initial: 'new',
+        states: {
+          new: {}
+        }
+      });
+
+      result.start();
+
+      assert.equal(result.currentState.value, 'new');
     });
 
-    assert.equal(result.currentState.value, 'new');
-  });
-
-  test('the statechart can send events to its states which will be handled by actions', function(assert) {
-    let stateChart = new Statechart({
-      initial: 'new',
-      states: {
-        new: {
-          on: {
-            woot: {
-              next: {
-                actions: [
-                  () => {
-                    assert.ok(true, 'stateChart forwarded event to its currentState which handled it via an action');
-                  }
-                ]
-              }
+    test('when the initial state has an `onEntry` property the provided actions will be executed on start', async function(assert) {
+      let result = new Statechart({
+        initial: 'new',
+        states: {
+          new: {
+            onEntry() {
+              assert.step('onEntry');
             }
-          }
-        },
-        next: {}
-      }
-    });
-
-    stateChart.send('woot');
-  });
-
-  test('it is possible to pass data when sending events', function(assert) {
-    let data = {
-      name: 'Tomster'
-    };
-    let stateChart = new Statechart({
-      initial: 'new',
-      states: {
-        new: {
-          on: {
-            woot: {
-              next: {
-                actions: [
-                  (eventData) => {
-                    assert.deepEqual(eventData, data, 'passing data works as expected');
-                  }
-                ]
-              }
-            }
-          }
-        },
-        next: {}
-      }
-    });
-
-    stateChart.send('woot', data);
-  });
-
-  test('if the currentState does not implement the sent event it does not break', function(assert) {
-    let stateChart = new Statechart({
-      initial: 'new',
-      states: {
-        new: {}
-      }
-    });
-
-    stateChart.send('wat');
-
-    assert.equal(stateChart.currentState.value, 'new');
-  });
-
-  test('state event handlers can transition to other states of the stateChart', async function(assert) {
-    let stateChart = new Statechart({
-      initial: 'new',
-      states: {
-        new: {
-          on: {
-            woot: 'next'
-          }
-        },
-        next: {}
-      }
-    });
-
-    assert.equal(stateChart.currentState, 'new', 'initial state was setup correctly');
-
-    await stateChart.send('woot');
-
-    assert.equal(stateChart.currentState.value, 'next', 'successfully transitioned into the new state');
-  });
-
-  test("when a new state is entered the old state's `onExit` function will be called and after that the newState's `onEntry` function`", async function(assert) {
-    assert.expect(4);
-
-    let someData = { woot: 'lol' };
-    let functionOrder = [];
-
-    let stateChart = new Statechart({
-      initial: 'new',
-      states: {
-        new: {
-          on: {
-            woot: 'next'
-          },
-          onExit(data) {
-            functionOrder.push('exitState');
-            assert.deepEqual(data, someData, 'states can pass data when they transition');
-          }
-        },
-        next: {
-          onEntry(data) {
-            functionOrder.push('enterState');
-            assert.deepEqual(data, someData, 'states can pass data when they transition');
           }
         }
-      }
+      });
+
+      await result.start();
+
+      assert.equal(result.currentState.value, 'new');
+
+      assert.verifySteps(['onEntry'], 'onEntry action was run');
     });
 
-    await stateChart.send('woot', someData);
-
-    assert.equal(stateChart.currentState.value, 'next', 'entered correct state');
-    assert.deepEqual(functionOrder, ['exitState', 'enterState'], 'exit and enter functions called in right order');
-  });
-
-  test("after a new state has been entered the stateChart's `didChangeState` function is called", async function(assert) {
-    let stateChart = new Statechart({
-      initial: 'new',
-      states: {
-        new: {
-          on: {
-            woot: 'next'
+    test('specifying onEntry action on an initial state via a string works', async function(assert) {
+      let result = new Statechart({
+        initial: 'new',
+        states: {
+          new: {
+            onEntry: 'checkCond',
           }
-        },
-        next: {}
-      },
-      didChangeState(newState) {
-        assert.equal(newState.value, 'next', 'new State passed to `didChangeState`');
-      }
+        }
+      }, {
+        actions: {
+          checkCond() {
+            assert.step('onEntry');
+          }
+        }
+      });
+
+      await result.start();
+
+      assert.equal(result.currentState.value, 'new');
+
+      assert.verifySteps(['onEntry']);
     });
 
-    await stateChart.send('woot');
+    test('specifying onEntry actions on an initial state via a string array works', async function(assert) {
+      let result = new Statechart({
+        initial: 'new',
+        states: {
+          new: {
+            onEntry: ['checkA', 'checkB'],
+          }
+        }
+      }, {
+        actions: {
+          checkA() {
+            assert.step('checkA');
+          },
+          checkB() {
+            assert.step('checkB');
+          }
+        }
+      });
+
+      await result.start();
+
+      assert.equal(result.currentState.value, 'new');
+
+      assert.verifySteps(['checkA', 'checkB'], 'onEntry functions are executed in the correct order');
+    });
+
+    test('specifying onEntry actions via a mixed array of strings and functions will only execute the string functions', async function(assert) {
+      let result = new Statechart({
+        initial: 'new',
+        states: {
+          new: {
+            onEntry: [() => { assert.step('inlineCheck'); }, 'checkCond']
+          }
+        }
+      }, {
+        actions: {
+          checkCond() {
+            assert.step('checkCond');
+          }
+        }
+      });
+
+      await result.start();
+
+      assert.equal(result.currentState.value, 'new');
+
+      assert.verifySteps(['checkCond']);
+    });
   });
 
-  test('StateCharts can be passed a context that the states have access to in their actions', async function(assert) {
-    let testContext = {
-      name: 'test context'
-    };
+  module('#send', function() {
+    test('state event handlers can transition to other states of the statechart when calling `send`', async function(assert) {
+      let statechart = new Statechart({
+        initial: 'new',
+        states: {
+          new: {
+            on: {
+              woot: 'next'
+            }
+          },
+          next: {}
+        }
+      });
 
-    let stateChart = new Statechart({
-      context: testContext,
-      initial: 'new',
-      states: {
-        new: {
-          on: {
-            woot: {
-              next: {
+      await statechart.start();
+
+      assert.equal(statechart.currentState.value, 'new', 'initial state was setup correctly');
+
+      await statechart.send('woot');
+
+      assert.equal(statechart.currentState.value, 'next', 'successfully transitioned into the new state');
+    });
+
+    test('transition to different states can be handled by actions', async function(assert) {
+      let statechart = new Statechart({
+        initial: 'new',
+        states: {
+          new: {
+            on: {
+              woot: {
+                target: 'next',
                 actions: [
-                  (data, context) => {
-                    assert.deepEqual(context, testContext, 'context is accessible in action handlers');
-                  }
+                  () => { assert.step('inlineAction'); },
+                  'wat'
                 ]
               }
             }
+          },
+          next: {}
+        }
+      }, {
+        actions: {
+          wat() {
+            assert.step('wat');
           }
-        },
-        next: {}
-      }
+        }
+      });
+
+      await statechart.start();
+
+      await statechart.send('woot');
+
+      assert.verifySteps(['wat'], 'functions as actions will be ignored because xstate >4.x does not support them');
     });
 
-    await stateChart.send('woot');
-  });
+    test('it is possible to pass data when sending events', async function(assert) {
+      const testData = {
+        name: 'Tomster'
+      };
 
-  test('when providing action names in the actions array they are executed on the passed context', async function(assert) {
-    assert.expect(3);
+      let statechart = new Statechart({
+        initial: 'new',
+        states: {
+          new: {
+            on: {
+              woot: {
+                target: 'next',
+                actions: [
+                  () => { assert.step('inlineAction'); },
+                  'wat'
+                ]
+              }
+            }
+          },
+          next: {}
+        }
+      }, {
+        actions: {
+          wat(data) {
+            assert.deepEqual(data, testData, 'data was passed as expected');
+          }
+        }
+      });
 
-    let testContext = {
-      woot(data, context) {
-        assert.deepEqual(data, testData, 'action executed with data passed');
-        assert.deepEqual(context, testContext, 'action executed with data passed');
-        assert.deepEqual(this, testContext, 'string actions executed on the context have the context set as `this`');
-      }
-    };
+      await statechart.start();
 
-    let testData = {
-      name: 'Tomster'
-    };
+      await statechart.send('woot', testData);
+    });
 
-    let stateChart = new Statechart({
-      context: testContext,
-      initial: 'new',
-      states: {
-        new: {
-          on: {
-            woot: {
-              next: {
+    test('transition to different states can be handled by multiple actions in sequence', async function(assert) {
+      let statechart = new Statechart({
+        initial: 'new',
+        states: {
+          new: {
+            on: {
+              woot: {
+                target: 'next',
+                actions: [
+                  'wat',
+                  'yo'
+                ]
+              }
+            }
+          },
+          next: {}
+        }
+      }, {
+        actions: {
+          wat() {
+            assert.step('actionA');
+          },
+          yo() {
+            assert.step('actionB')
+          }
+        }
+      });
+
+      await statechart.start();
+
+      await statechart.send('woot');
+
+      assert.verifySteps(['actionA', 'actionB'], 'actions fire in the correct order');
+    });
+
+    test('when specifying multiple actions all actions will be passed the event data', async function(assert) {
+      const testData = {
+        name: 'Tomster'
+      };
+
+      let statechart = new Statechart({
+        initial: 'new',
+        states: {
+          new: {
+            on: {
+              woot: {
+                target: 'next',
+                actions: [
+                  'wat',
+                  'yo'
+                ]
+              }
+            }
+          },
+          next: {}
+        }
+      }, {
+        actions: {
+          wat(data) {
+            assert.deepEqual(data, testData, 'actionA got passed correct data');
+            assert.step('actionA');
+          },
+          yo(data) {
+            assert.deepEqual(data, testData, 'actionA got passed correct data');
+            assert.step('actionB')
+          }
+        }
+      });
+
+      await statechart.start();
+
+      await statechart.send('woot', testData);
+
+      assert.verifySteps(['actionA', 'actionB'], 'actions fire in the correct order');
+    });
+
+
+    test('if the currentState does not implement the sent event it does not break', async function(assert) {
+      let statechart = new Statechart({
+        initial: 'new',
+        states: {
+          new: {}
+        }
+      });
+
+      await statechart.start();
+      await statechart.send('wat');
+
+      assert.equal(statechart.currentState.value, 'new');
+    });
+
+    test("when a new state is entered the old state's `onExit` function will be called and after that the newState's `onEntry` function`", async function(assert) {
+      let someData = { woot: 'lol' };
+
+      let statechart = new Statechart({
+        initial: 'new',
+        states: {
+          new: {
+            on: {
+              woot: 'next'
+            },
+            onExit(data) {
+              assert.step('exitState');
+              assert.deepEqual(data, someData, 'states can pass data when they transition');
+            }
+          },
+          next: {
+            onEntry(data) {
+              assert.step('enterState');
+              assert.deepEqual(data, someData, 'states can pass data when they transition');
+            }
+          }
+        }
+      });
+
+      await statechart.start();
+
+      await statechart.send('woot', someData);
+
+      assert.equal(statechart.currentState.value, 'next', 'entered correct state');
+      assert.verifySteps(['exitState', 'enterState'], 'exit and enter functions called in right order');
+    });
+
+    test("after a new state has been entered the statechart's `didChangeState` function is called", async function(assert) {
+      let statechart = new Statechart({
+        initial: 'new',
+        states: {
+          new: {
+            on: {
+              woot: 'next'
+            }
+          },
+          next: {}
+        },
+        didChangeState(newState) {
+          assert.equal(newState.value, 'next', 'new State passed to `didChangeState`');
+        }
+      });
+
+      await statechart.start();
+
+      await statechart.send('woot');
+    });
+
+    test('StateCharts can be passed a context that the states have access to in their actions', async function(assert) {
+      let testContext = {
+        name: 'test context'
+      };
+
+      let statechart = new Statechart({
+        context: testContext,
+        initial: 'new',
+        states: {
+          new: {
+            on: {
+              woot: {
+                target: 'next',
+                actions: ['test'],
+              }
+            }
+          },
+          next: {}
+        }
+      }, {
+        actions: {
+          test(_data, context) {
+            assert.deepEqual(context, testContext, 'context is accessible in action handlers');
+          }
+        }
+      });
+
+      await statechart.start();
+
+      await statechart.send('woot');
+    });
+
+    test('when providing action names in the actions array they are executed on the passed context', async function(assert) {
+      assert.expect(3);
+
+      let testContext = {
+        woot(data, context) {
+          assert.deepEqual(data, testData, 'action executed with data passed');
+          assert.deepEqual(context, testContext, 'action executed with data passed');
+          assert.deepEqual(this, testContext, 'string actions executed on the context have the context set as `this`');
+        }
+      };
+
+      let testData = {
+        name: 'Tomster'
+      };
+
+      let statechart = new Statechart({
+        context: testContext,
+        initial: 'new',
+        states: {
+          new: {
+            on: {
+              woot: {
+                target: 'next',
                 actions: ['woot']
               }
             }
-          }
-        },
-        next: {}
-      }
+          },
+          next: {}
+        }
+      }, {
+        actions: {
+          woot: testContext.woot
+        }
+      });
+
+      await statechart.start();
+
+      await statechart.send('woot', testData);
     });
 
-    await stateChart.send('woot', testData);
-  });
+    test('Statecharts can implement guards to determine if a transition should occur between states', async function(assert) {
+      assert.expect(6);
 
-  test('when providing action names in the actions array and no context exists it does not break', async function(assert) {
-    let stateChart = new Statechart({
-      initial: 'new',
-      states: {
-        new: {
-          on: {
-            woot: {
-              next: {
-                actions: ['woot']
-              }
-            }
-          }
-        },
-        next: {}
-      }
-    });
+      let testData = {
+        name: 'Tomster'
+      };
 
-    await stateChart.send('woot');
+      let testContext = {
+        name: 'test context'
+      };
 
-    assert.equal(stateChart.currentState.value, 'next');
-  });
-
-  test('Statecharts can implement guards to determine if a transition should occur between states', async function(assert) {
-    assert.expect(6);
-
-    let testData = {
-      name: 'Tomster'
-    };
-
-    let testContext = {
-      name: 'test context'
-    };
-
-    let stateChart = new Statechart({
-      initial: 'new',
-      context: testContext,
-      states: {
-        new: {
-          on: {
-            woot: {
-              next: {
+      let statechart = new Statechart({
+        initial: 'new',
+        context: testContext,
+        states: {
+          new: {
+            on: {
+              woot: {
+                target: 'next',
                 cond: (extendedState, eventObject) => {
                   let { type, data } = eventObject;
                   assert.equal(type, 'woot', 'eventName is accessible in condition');
@@ -263,507 +442,600 @@ module('Unit | Utility | statechart', function(/*hooks*/) {
 
                   return false;
                 },
-                actions: [
-                  () => assert.ok(false, "no action will be called as we won't transition because of `woot`-event")
-                ]
-              }
-            },
-            foo: {
-              next: {
+                actions: ['wootAction']
+              },
+              foo: {
+                target: 'next',
                 cond: () => {
-                  return true;
+                  return true
                 },
                 actions: [
-                  () => assert.ok(true, 'returning `true` from a condition will trigger a transition')
+                  'fooAction'
                 ]
               }
             }
-          }
-        },
-        next: {}
-      }
-    });
-
-    await stateChart.send('woot', testData);
-
-    assert.equal(stateChart.currentState.value, 'new', 'woot did not trigger a transition');
-
-    await stateChart.send('foo', testData);
-
-    assert.equal(stateChart.currentState.value, 'next', 'foo did trigger a transition');
-  });
-
-  test('StateCharts can be nested', async function(assert) {
-    let stateChart = new Statechart({
-      initial: 'off',
-      states: {
-        off: {
-          on: {
-            power: 'on'
-          }
-        },
-        on: {
-          initial: 'stopped',
-          states: {
-            stopped: {},
-            playing: {},
-            paused: {}
+          },
+          next: {}
+        }
+      }, {
+        actions: {
+          wootAction() {
+            assert.ok(false, "no action will be called as we won't transition because of `woot`-event")
+          },
+          fooAction() {
+            assert.ok(true, 'returning `true` from a condition will trigger a transition')
           }
         }
-      }
+      });
+
+      await statechart.start();
+      await statechart.send('woot', testData);
+
+      assert.equal(statechart.currentState.value, 'new', 'woot did not trigger a transition');
+
+      await statechart.send('foo', testData);
+
+      assert.equal(statechart.currentState.value, 'next', 'foo did trigger a transition');
     });
 
-    assert.equal(stateChart.currentState.value, 'off');
+    test('guards can be used to conditionally transition into different states based on the same event', async function(assert) {
+      const testContext = {
+        power: 1
+      };
 
-    await stateChart.send('power');
-
-    assert.deepEqual(stateChart.currentState.value, { on: 'stopped' }, 'nested states will return an object as their `value`');
-  });
-
-  test('Statechart transitions in nested states work', async function(assert) {
-    assert.expect(3);
-    let stateChart = new Statechart({
-      initial: 'on',
-      states: {
-        off: {
-          on: {
-            power: 'on'
-          }
-        },
-        on: {
-          initial: 'stopped',
-          states: {
-            stopped: {
-              on: {
-                play: 'playing'
-              }
-            },
-            playing: {},
-            paused: {}
-          },
-          on: {
-            power: 'off'
-          }
-        }
-      }
-    });
-
-    assert.deepEqual(stateChart.currentState.value, { on: 'stopped' });
-
-    await stateChart.send('play');
-
-    assert.deepEqual(stateChart.currentState.value, { on: 'playing' });
-
-    await stateChart.send('power');
-
-    assert.deepEqual(stateChart.currentState.value, 'off');
-  });
-
-  test('nested statecharts have access to the top-level context object', async function(assert) {
-    assert.expect(8);
-
-    let testContext = {
-      name: 'lol'
-    };
-
-    let stateChart = new Statechart({
-      initial: 'off',
-      context: testContext,
-
-      states: {
-        off: {
-          on: {
-            power: 'on'
-          }
-        },
-        on: {
-          initial: 'stopped',
-          states: {
-            stopped: {
-              onEntry(data, context) {
-                assert.deepEqual(context, testContext, 'context is available as expected');
-              },
-              onExit(data, context) {
-                assert.equal(context.name, 'lol');
-              },
-              on: {
-                play: {
-                  playing: {
-                    actions: [
-                      (data, context) => { assert.deepEqual(context, testContext) }
-                    ]
-                  }
-                }
-              }
-            },
-            playing: {},
-            paused: {}
-          },
-          on: {
-            power: {
-              off: {
-                actions: [
-                  (data, context) => { assert.deepEqual(context, testContext) }
-                ]
-              }
-            }
-          }
-        }
-      }
-    });
-
-    assert.equal(stateChart.currentState.value, 'off');
-
-    await stateChart.send('power');
-
-    assert.deepEqual(stateChart.currentState.value, { on: 'stopped' });
-
-    await stateChart.send('play');
-
-    assert.deepEqual(stateChart.currentState.value, { on: 'playing' });
-
-    await stateChart.send('power');
-
-    assert.equal(stateChart.currentState.value, 'off');
-  });
-
-  test('nested statecharts will execute onEntry handlers for the chart first and then for the initial state of the nested chart', async function(assert) {
-    assert.expect(5);
-
-    let testContext = {
-      executionOrder: []
-    };
-
-    let testData = {
-      wat: 'lol'
-    };
-
-    let stateChart = new Statechart({
-      initial: 'off',
-      context: testContext,
-
-      states: {
-        off: {
-          on: {
-            power: 'on'
-          }
-        },
-        on: {
-          initial: 'stopped',
-          states: {
-            stopped: {
-              onEntry(data, context) {
-                assert.deepEqual(data, testData, 'data passed via send will be available in substates as well');
-                context.executionOrder.push('stopped')
-              }
-            },
-            playing: {
-              onEntry(data, context) {
-                context.executionOrder.push('wat');
-              }
-            }
-          },
-          onEntry(data, context) {
-            assert.deepEqual(data, testData, 'data passed from goToState wil be available in enterState');
-            context.executionOrder.push('on');
-          }
-        }
-      }
-    });
-
-    assert.equal(stateChart.currentState.value, 'off');
-
-    await stateChart.send('power', testData);
-
-    assert.deepEqual(stateChart.currentState.value, { on: 'stopped' });
-    assert.deepEqual(testContext.executionOrder, ['on', 'stopped']);
-  });
-
-  test('nested statecharts will execute exitState handlers for substate first and then for the chart', async function(assert) {
-    assert.expect(3);
-
-    let testContext = {
-      executionOrder: []
-    };
-
-    let stateChart = new Statechart({
-      initial: 'on',
-      context: testContext,
-
-      states: {
-        off: {},
-        on: {
-          initial: 'stopped',
-          states: {
-            stopped: {
-              onExit(data, context) {
-                context.executionOrder.push('stopped')
-              }
-            },
-            playing: {
-              onExit(data, context) {
-                context.executionOrder.push('wat');
-              }
-            }
-          },
-          onExit(data, context) {
-            context.executionOrder.push('on');
-          },
-          on: {
-            power: 'off'
-          }
-        }
-      }
-    });
-
-    assert.deepEqual(stateChart.currentState.value, { on: 'stopped' });
-
-    await stateChart.send('power');
-
-    assert.equal(stateChart.currentState.value, 'off');
-    assert.deepEqual(testContext.executionOrder, ['stopped', 'on']);
-  });
-
-  test('when exiting a nested states and entering again we will start out in the default initial state again', async function(assert) {
-    let stateChart = new Statechart({
-      initial: 'on',
-      states: {
-        off: {
-          on: {
-            power: 'on'
-          }
-        },
-        on: {
-          initial: 'stopped',
-          states: {
-            stopped: {
-              on: {
-                play: 'playing'
-              }
-            },
-            playing: {}
-          },
-          on: {
-            power: 'off'
-          }
-        }
-      }
-    });
-
-    assert.deepEqual(stateChart.currentState.value, { on: 'stopped' });
-
-    await stateChart.send('play');
-
-    assert.deepEqual(stateChart.currentState.value, { on: 'playing' });
-
-    await stateChart.send('power');
-
-    assert.equal(stateChart.currentState.value, 'off');
-
-    await stateChart.send('power');
-
-    assert.deepEqual(stateChart.currentState.value, { on: 'stopped' });
-  });
-
-  test('statecharts can be nested multiple levels deep', async function(assert) {
-    let stateChart = new Statechart({
-      initial: 'a',
-      states: {
-        a: {
-          initial: 'aa',
-          states: {
-            aa: {
-              initial: 'aaa',
-              states: {
-                aaa: {
-                  initial: 'aaaa',
-                  states: {
-                    aaaa: {
-                      on: {
-                        aaab: 'aaab'
-                      }
-                    },
-                    aaab: {}
+      const statechart = new Statechart({
+        context: testContext,
+        initial: 'fighting',
+        states: {
+          fighting: {
+            on: {
+              strike: [
+                {
+                  target: 'won',
+                  cond(extendedState) {
+                    return extendedState.power > 9000;
                   }
                 },
-                aab: {}
-              },
-              on: {
-                ab: 'ab'
-              }
-            },
-            ab: {}
-          }
+                {
+                  target: 'fighting',
+                },
+              ]
+            }
+          },
+          won: {}
         }
-      }
+      });
+
+      await statechart.start();
+
+      await statechart.send('strike');
+
+      assert.equal(statechart.currentState.value, 'fighting', 'transition did not happen because of condition');
+
+      testContext.power = 9001;
+
+      await statechart.send('strike');
+
+      assert.equal(statechart.currentState.value, 'won', 'transition did happen because power is now over 9000');
     });
 
-    assert.deepEqual(stateChart.currentState.value, {
-      a: {
-        aa: {
-          aaa: 'aaaa'
-        }
-      }
-    });
+    test('it supports strings as guard conditions', async function(assert) {
+      let testContext = {
+        name: 'Tomster'
+      };
 
-    await stateChart.send('aaab');
+      let testData = {
+        canTransition: true
+      };
 
-    assert.deepEqual(stateChart.currentState.value, {
-      a: {
-        aa: {
-          aaa: 'aaab'
-        }
-      }
-    });
-
-    await stateChart.send('ab');
-
-    assert.deepEqual(stateChart.currentState.value, {
-      a: 'ab'
-    });
-  });
-
-  test('statecharts can have orthogonal states', async function(assert) {
-    assert.expect(10);
-
-    let testContext = {
-      name: 'wat',
-      woot(data, context) {
-        assert.deepEqual(data, testData, 'passing data works in string actions');
-        assert.deepEqual(context, testContext, 'context is passed in string actions');
-      }
-    };
-
-    let testData = {
-      message: 'success!'
-    };
-
-    let stateChart = new Statechart({
-      parallel: true,
-      context: testContext,
-      states: {
-        upload: {
-          initial: 'idle',
-          states: {
-            idle: {
-              on: {
-                INIT_UPLOAD: 'pending'
-              }
-            },
-            pending: {
-              on: {
-                UPLOAD_COMPLETE: {
-                  success: {
-                    actions: [
-                      (data, context) => {
-                        assert.deepEqual(data, testData, 'passing data works');
-                        assert.deepEqual(context, testContext, 'context is passed as expected');
-                      }
-                    ]
-                  }
-                }
-              }
-            },
-            success: {}
-          }
-        },
-        download: {
-          initial: 'idle',
-          states: {
-            idle: {
-              on: {
-                INIT_DOWNLOAD: {
-                  pending: {
-                    actions: ['woot']
-                  }
-                }
-              }
-            },
-            pending: {
-              onEntry(data, context) {
-                assert.deepEqual(data, testData, 'passing data works');
-                assert.deepEqual(context, testContext, 'context is passed as expected');
-              },
-              on: {
-                DOWNLOAD_COMPLETE: 'success'
-              }
-            },
-            success: {}
-          }
-        }
-      }
-    });
-
-    assert.deepEqual(stateChart.currentState.value, {
-      upload: 'idle',
-      download: 'idle'
-    }, 'parallel/orthogonal states work as expected');
-
-    await stateChart.send('INIT_UPLOAD');
-
-    assert.deepEqual(stateChart.currentState.value, {
-      upload: 'pending',
-      download: 'idle'
-    }, 'parallel states can handle events');
-
-    await stateChart.send('INIT_DOWNLOAD', testData);
-
-    assert.deepEqual(stateChart.currentState.value, {
-      upload: 'pending',
-      download: 'pending'
-    }, 'second parallel state can handle events');
-
-    await stateChart.send('UPLOAD_COMPLETE', testData);
-
-    assert.deepEqual(stateChart.currentState.value, {
-      upload: 'success',
-      download: 'pending'
-    }, 'parallel states have expected end states');
-  });
-
-  test('it supports strings as guard conditions', async function(assert) {
-    let testContext = {
-      name: 'Tomster'
-    };
-
-    let testData = {
-      canTransition: true
-    };
-
-    let stateChart = new Statechart({
-      context: testContext,
-      initial: 'powerOff',
-      states: {
-        powerOff: {
-          on: {
-            power: {
-              powerOn: {
+      let statechart = new Statechart({
+        context: testContext,
+        initial: 'powerOff',
+        states: {
+          powerOff: {
+            on: {
+              power: {
+                target: 'powerOn',
                 cond: 'canTransition'
               }
             }
-          }
-        },
-        powerOn: {}
-      }
-    }, {
-      guards: {
-        canTransition: (extendedState, eventObject) => {
-          assert.equal(extendedState.name, 'Tomster', 'machine guard functions can access the statecharts context');
-
-          let { type, data: eventData } = eventObject;
-
-          assert.equal(type, 'power', 'eventObject contains name of event that was sent');
-          assert.deepEqual(eventData, testData, 'data passed to event is available in guards');
-
-          return eventData.canTransition;
+          },
+          powerOn: {}
         }
-      }
+      }, {
+        guards: {
+          canTransition: (extendedState, eventObject) => {
+            assert.equal(extendedState.name, 'Tomster', 'machine guard functions can access the statecharts context');
+
+            let { type, data: eventData } = eventObject;
+
+            assert.equal(type, 'power', 'eventObject contains name of event that was sent');
+            assert.deepEqual(eventData, testData, 'data passed to event is available in guards');
+
+            return eventData.canTransition;
+          }
+        }
+      });
+
+      await statechart.start();
+
+      assert.equal(statechart.currentState.value, 'powerOff');
+
+      await statechart.send('power', testData);
+
+      assert.equal(statechart.currentState.value, 'powerOn');
     });
 
-    assert.equal(stateChart.currentState.value, 'powerOff');
+    test('when `start` takes some time and we send an event the event gets enqueued', async function(assert) {
+      const done = assert.async();
+      let _resolve;
+      let promise = new Promise((resolve) => {
+        _resolve = resolve;
+      })
 
-    await stateChart.send('power', testData);
+      const statechart = new Statechart({
+        initial: 'asyncInitial',
+        states: {
+          asyncInitial: {
+            onEntry() {
+              return promise;
+            },
 
-    assert.equal(stateChart.currentState.value, 'powerOn');
+            on: {
+              power: 'powerOn'
+            }
+          },
+          powerOn: {
+            onEntry: ['assertAllOk']
+          }
+        }
+      }, {
+        actions: {
+          assertAllOk() {
+            assert.ok(true, 'power got send after statechart initialized');
+            done();
+          }
+        }
+      });
+
+      statechart.start();
+
+      statechart.send('power');
+
+      _resolve();
+    });
+  });
+
+
+  module('nesting', function() {
+    test('StateCharts can be nested', async function(assert) {
+      let statechart = new Statechart({
+        initial: 'off',
+        states: {
+          off: {
+            on: {
+              power: 'on'
+            }
+          },
+          on: {
+            initial: 'stopped',
+            states: {
+              stopped: {},
+              playing: {},
+              paused: {}
+            }
+          }
+        }
+      });
+
+      await statechart.start();
+
+      assert.equal(statechart.currentState.value, 'off');
+
+      await statechart.send('power');
+
+      assert.deepEqual(statechart.currentState.value, { on: 'stopped' }, 'nested states will return an object as their `value`');
+    });
+
+    test('Statechart transitions in nested states work', async function(assert) {
+      assert.expect(3);
+
+      let statechart = new Statechart({
+        initial: 'on',
+        states: {
+          off: {
+            on: {
+              power: 'on'
+            }
+          },
+          on: {
+            initial: 'stopped',
+            states: {
+              stopped: {
+                on: {
+                  play: 'playing'
+                }
+              },
+              playing: {},
+              paused: {}
+            },
+            on: {
+              power: 'off'
+            }
+          }
+        }
+      });
+
+      await statechart.start();
+
+      assert.deepEqual(statechart.currentState.value, { on: 'stopped' });
+
+      await statechart.send('play');
+
+      assert.deepEqual(statechart.currentState.value, { on: 'playing' });
+
+      await statechart.send('power');
+
+      assert.deepEqual(statechart.currentState.value, 'off');
+    });
+    test('nested statecharts have access to the top-level context object', async function(assert) {
+      assert.expect(8);
+
+      let testContext = {
+        name: 'lol'
+      };
+
+      let statechart = new Statechart({
+        initial: 'off',
+        context: testContext,
+
+        states: {
+          off: {
+            on: {
+              power: 'on'
+            }
+          },
+          on: {
+            initial: 'stopped',
+            states: {
+              stopped: {
+                onEntry(data, context) {
+                  assert.deepEqual(context, testContext, 'context is available as expected');
+                },
+                onExit(data, context) {
+                  assert.equal(context.name, 'lol');
+                },
+                on: {
+                  play: {
+                    target: 'playing',
+                    actions: ['testTestContext']
+                  }
+                }
+              },
+              playing: {},
+              paused: {}
+            },
+            on: {
+              power: {
+                target: 'off',
+                actions: ['testTestContext']
+              }
+            }
+          }
+        }
+      }, {
+        actions: {
+          testTestContext(data, context) {
+            assert.deepEqual(context, testContext);
+          }
+        }
+      });
+
+      await statechart.start();
+
+      assert.equal(statechart.currentState.value, 'off');
+
+      await statechart.send('power');
+
+      assert.deepEqual(statechart.currentState.value, { on: 'stopped' });
+
+      await statechart.send('play');
+
+      assert.deepEqual(statechart.currentState.value, { on: 'playing' });
+
+      await statechart.send('power');
+
+      assert.equal(statechart.currentState.value, 'off');
+    });
+
+    test('nested statecharts will execute onEntry handlers for the chart first and then for the initial state of the nested chart', async function(assert) {
+      let testData = {
+        wat: 'lol'
+      };
+
+      let statechart = new Statechart({
+        initial: 'off',
+
+        states: {
+          off: {
+            on: {
+              power: 'on'
+            }
+          },
+          on: {
+            initial: 'stopped',
+            states: {
+              stopped: {
+                onEntry(data) {
+                  assert.deepEqual(data, testData, 'data passed via send will be available in substates as well');
+                  assert.step('stopped');
+                }
+              },
+              playing: {
+                onEntry() {
+                  assert.step('wat');
+                }
+              }
+            },
+            onEntry(data) {
+              assert.deepEqual(data, testData, 'data passed from goToState wil be available in enterState');
+              assert.step('on');
+            }
+          }
+        }
+      });
+
+      await statechart.start();
+
+      assert.equal(statechart.currentState.value, 'off');
+
+      await statechart.send('power', testData);
+
+      assert.deepEqual(statechart.currentState.value, { on: 'stopped' });
+      assert.verifySteps(['on', 'stopped']);
+    });
+
+    test('nested statecharts will execute exitState handlers for substate first and then for the chart', async function(assert) {
+      let statechart = new Statechart({
+        initial: 'on',
+
+        states: {
+          off: {},
+          on: {
+            initial: 'stopped',
+            states: {
+              stopped: {
+                onExit() {
+                  assert.step('stopped');
+                }
+              },
+              playing: {
+                onExit() {
+                  assert.step('wat');
+                }
+              }
+            },
+            onExit() {
+              assert.step('on')
+            },
+            on: {
+              power: 'off'
+            }
+          }
+        }
+      });
+
+      await statechart.start();
+      assert.deepEqual(statechart.currentState.value, { on: 'stopped' });
+
+      await statechart.send('power');
+
+      assert.equal(statechart.currentState.value, 'off');
+      assert.verifySteps(['stopped', 'on']);
+    });
+
+    test('when exiting a nested states and entering again we will start out in the default initial state again', async function(assert) {
+
+      let statechart = new Statechart({
+        initial: 'on',
+        states: {
+          off: {
+            on: {
+              power: 'on'
+            }
+          },
+          on: {
+            initial: 'stopped',
+            states: {
+              stopped: {
+                on: {
+                  play: 'playing'
+                }
+              },
+              playing: {}
+            },
+            on: {
+              power: 'off'
+            }
+          }
+        }
+      });
+
+      await statechart.start();
+
+      assert.deepEqual(statechart.currentState.value, { on: 'stopped' });
+
+      await statechart.send('play');
+
+      assert.deepEqual(statechart.currentState.value, { on: 'playing' });
+
+      await statechart.send('power');
+
+      assert.equal(statechart.currentState.value, 'off');
+
+      await statechart.send('power');
+
+      assert.deepEqual(statechart.currentState.value, { on: 'stopped' });
+    });
+
+    test('statecharts can be nested multiple levels deep', async function(assert) {
+      let statechart = new Statechart({
+        initial: 'a',
+        states: {
+          a: {
+            initial: 'aa',
+            states: {
+              aa: {
+                initial: 'aaa',
+                states: {
+                  aaa: {
+                    initial: 'aaaa',
+                    states: {
+                      aaaa: {
+                        on: {
+                          aaab: 'aaab'
+                        }
+                      },
+                      aaab: {}
+                    }
+                  },
+                  aab: {}
+                },
+                on: {
+                  ab: 'ab'
+                }
+              },
+              ab: {}
+            }
+          }
+        }
+      });
+
+      await statechart.start();
+
+      assert.deepEqual(statechart.currentState.value, {
+        a: {
+          aa: {
+            aaa: 'aaaa'
+          }
+        }
+      });
+
+      await statechart.send('aaab');
+
+      assert.deepEqual(statechart.currentState.value, {
+        a: {
+          aa: {
+            aaa: 'aaab'
+          }
+        }
+      });
+
+      await statechart.send('ab');
+
+      assert.deepEqual(statechart.currentState.value, {
+        a: 'ab'
+      });
+    });
+
+    test('statecharts can have orthogonal states', async function(assert) {
+      assert.expect(10);
+
+      let testContext = {
+        name: 'wat',
+      };
+
+      let testData = {
+        message: 'success!'
+      };
+
+      let statechart = new Statechart({
+        context: testContext,
+        type: 'parallel',
+        states: {
+          upload: {
+            initial: 'idle',
+            states: {
+              idle: {
+                on: {
+                  INIT_UPLOAD: 'pending'
+                }
+              },
+              pending: {
+                on: {
+                  UPLOAD_COMPLETE: {
+                    target: 'success',
+                    actions: ['handleUploadSuccess']
+                  }
+                }
+              },
+              success: {}
+            }
+          },
+          download: {
+            initial: 'idle',
+            states: {
+              idle: {
+                on: {
+                  INIT_DOWNLOAD: {
+                    target: 'pending',
+                    actions: ['handleInitDownload']
+                  }
+                }
+              },
+              pending: {
+                onEntry(data, context) {
+                  assert.deepEqual(data, testData, 'passing data works');
+                  assert.deepEqual(context, testContext, 'context is passed as expected');
+                },
+                on: {
+                  DOWNLOAD_COMPLETE: 'success'
+                }
+              },
+              success: {}
+            }
+          }
+        }
+      }, {
+        actions: {
+          handleUploadSuccess(data, context) {
+            assert.deepEqual(data, testData, 'passing data works');
+            assert.deepEqual(context, testContext, 'context is passed as expected');
+          },
+          handleInitDownload(data, context) {
+            assert.deepEqual(data, testData, 'passing data works');
+            assert.deepEqual(context, testContext, 'context is passed');
+          }
+        }
+      });
+
+      await statechart.start();
+
+      assert.deepEqual(statechart.currentState.value, {
+        upload: 'idle',
+        download: 'idle'
+      }, 'parallel/orthogonal states work as expected');
+
+      await statechart.send('INIT_UPLOAD');
+
+      assert.deepEqual(statechart.currentState.value, {
+        upload: 'pending',
+        download: 'idle'
+      }, 'parallel states can handle events');
+
+      await statechart.send('INIT_DOWNLOAD', testData);
+
+      assert.deepEqual(statechart.currentState.value, {
+        upload: 'pending',
+        download: 'pending'
+      }, 'second parallel state can handle events');
+
+      await statechart.send('UPLOAD_COMPLETE', testData);
+
+      assert.deepEqual(statechart.currentState.value, {
+        upload: 'success',
+        download: 'pending'
+      }, 'parallel states have expected end states');
+    });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -8819,9 +8819,10 @@ xregexp@4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/xregexp/-/xregexp-4.0.0.tgz#e698189de49dd2a18cc5687b05e17c8e43943020"
 
-xstate@^3.3.3:
-  version "3.3.3"
-  resolved "https://registry.yarnpkg.com/xstate/-/xstate-3.3.3.tgz#64177cd4473d4c2424b3df7d2434d835404b09a9"
+xstate@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/xstate/-/xstate-4.0.1.tgz#a9d415280605ccc8c5b9442a87511eeb1d34eee3"
+  integrity sha512-NYC4iCj+i2I3yA7qvFk7SMOEfzqUmoBo2imHyZL4OJtTZojy8P60zbWgVL0+8GjoaqCnyNilUUjmT0RFqcPXIg==
 
 "xtend@>=4.0.0 <4.1.0-0", xtend@^4.0.0, xtend@~4.0.0, xtend@~4.0.1:
   version "4.0.1"


### PR DESCRIPTION
This updates the project to make use of xstate `4.x.`. Quite a bit has changed - You can look at the [xstate release-notes]([https://github.com/davidkpiano/xstate/releases/tag/v4.0.0] ) to see the details what needs to be changed in your statechart-configuration. Overall the new way to declare statecharts cleans everything quite a bit.

String actions that will call functions on the statechart's context object won't work anymore. Anonymous functions only declared inline in the statechart config also stop working. Actions need to be declared on the options passed to the statechart config. Example:

```js
O.extend({
  machineIsOn: false,

  statechart: statechart({
    initial: 'powerOff',
    states: {
      powerOff: {
        onEntry: ['turnMachineOff'],

        on: {
          power: {
            target: 'powerOn',
            actions: ['turnMachineOn']
          }
        }
      },
      powerOn: {
        on: {
           // "simple" transitions still work as usual
           power: 'powerOff'
        }
      }
    }
  }, {
    actions: {
      turnMachineOn(/* data, context*/) {
        // `this` is the object that implements the statechart
        this.set('machineIsOn', true);
      },
      turnMachineOff() {
        this.set('machineIsOn', false); 
      }
    }
  })
})
```

The statechart computed will now only work with xstate 4.x compliant configurations.

## Other relevant changes:

* The statechart will now execute the `onEntry` actions of the initialState when being created. Example:

```js
O.extend({
  statechart: statechart({
    initial: 'willInit',
     states: {
       willInit: {
          onEntry: ['initAsync'],
          on: {
             resolve: 'success',
             reject: 'error'
           }
        },
        // ...
      }
  }, {
    actions: {
      initAsync() {
        return this.somethingAsync()
          .then(() => this.statechart.send('resolve'))
          .catch(() => this.statechart.send('reject'));
      }
    }
  })
})
```
* when statechart initialization is async send calls will be enqueued until initialization

Example:

```js
const o = O.extend({
  statechart: statechart({
    initial: 'willInit',
     states: {
       willInit: {
          onEntry: ['initAsync'],
          on: {
             click: 'busy',
           }
        },
        busy: {
          onEntry: ['beBusy']
        }
        // ...
      }
  }, {
    actions: {
      initAsync() {
        return this.somethingAsync();
      },
      beBusy() {
        console.log("I'm busy now");
      }
    }
  })
}).create();

// this will initialize the statechart and execute `initAsync`
const sc = o.get('statechart');

// we don't wait and send an event right away
sc.send('click');

// after `initAsync` has finished
// => "I'm busy"
```

Although this works modeling this explicitely via a transient state is most likely the better option:

```js
O.extend({
  statechart: statechart({
    initial: 'willInit'
    states: {
      willInit: {
        on: {
           init: 'initializing'
        }
      },
      initializing: {
        onEntry: ['asyncCall'],
        on: {
          resolve: 'success',
          reject: 'error'
        }
      }
     },
     // ...
  }, {
    actions: {
      asyncCall() {
        // ...
      }
    }
  })
}) 
```

## Notes
xstate now supports [activities](https://xstate.js.org/docs/guides/activities/) and [delays](https://xstate.js.org/docs/guides/delays/). `ember-statecharts` does not support those featues. If you want to build something that makes use of similiar functionality you are encouraged to use [ember-concurrency](http://ember-concurrency.com/docs/introduction/) instead. Example:

```js
const trafficLight = O.extend({
  statechart: statechart({
    initial: 'red',
    states: {
      red: {
        onEntry: ['startTimer'],
        on: {
          timer: 'yellow'
        }
      },
      yellow: {
        // ...
      },
      // ...
    }
  }, {
    actions: {
      startTimer() {
        this.timerTask.perform();
      }
     }
  }),
  timerTask: task(function *() {
    yield timeout(TIMEOUT);
    this.statechart.send('timer');
  })
});
```