### PR TITLE
Use xstate interpreter

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -11,6 +11,7 @@ module.exports = {
   },
   rules: {
     'prettier/prettier': 'error',
+    'no-unused-vars': ['error', { ignoreRestSiblings: true }],
   },
   overrides: [
     // node files

--- a/README.md
+++ b/README.md
@@ -117,8 +117,8 @@ export default Component.extend({
     }
   }, {
     actions: {
-      executeOnClick(/* data, context */) {
-        // `this` references the object that includes the statechart
+      executeOnClick(/*context, { eventObject } */) {
+        // `context` references the object that includes the statechart
         return resolve()
           .then(() => this.onClick())
           .then(() => this.statechart.send('resolve'))

--- a/addon/utils/statechart.js
+++ b/addon/utils/statechart.js
@@ -35,7 +35,8 @@ export default class Statechart {
         );
       }
       const eventObject = { ...eventData, type: event };
-      this.service.send(eventObject);
+
+      this._sendEventObject(eventObject);
     }
   }
 

--- a/addon/utils/statechart.js
+++ b/addon/utils/statechart.js
@@ -1,10 +1,20 @@
 import { Machine, interpret } from 'xstate';
 import { set } from '@ember/object';
+import { later, cancel } from '@ember/runloop';
 
 export default class Statechart {
   constructor(config, options, initialContext) {
     const machine = Machine(config, options, initialContext);
-    this.service = interpret(machine)
+    this.service = interpret(machine, {
+      clock: {
+        setTimeout: (fn, ms) => {
+          return later.call(null, fn, ms);
+        },
+        clearTimeout: timer => {
+          return cancel.call(null, timer);
+        },
+      },
+    })
       .onTransition(state => {
         set(this, 'currentState', state);
       })

--- a/addon/utils/statechart.js
+++ b/addon/utils/statechart.js
@@ -1,149 +1,17 @@
-import { Promise, resolve } from 'rsvp';
-import { Machine } from 'xstate';
+import { Machine, interpret } from 'xstate';
 import { set } from '@ember/object';
 
-function noOp() {}
-
-class Interpreter {
-  constructor({ config, options, context }) {
-    this.machine = Machine(config, options);
-
-    this.currentState = this.machine.initialState;
-
-    this.context = context;
-  }
-
-  send(eventName, data) {
-    const newState = this.machine.transition(
-      this.currentState,
-      { type: eventName, data },
-      this.context
-    );
-
-    this.currentState = newState;
-
-    let { actions } = newState;
-
-    let _actions = actions.map(action => action.exec.bind(this.context));
-
-    let chain = _actions.reduce((acc, action) => {
-      return acc.then(() => {
-        return action(data);
-      });
-    }, resolve());
-
-    return chain;
-  }
-}
-
 export default class Statechart {
-  constructor(config, options) {
-    this.machine = Machine(config, options);
-    this.sendQueue = [];
-
-    this.service = new Interpreter({
-      config: {
-        initial: 'initializing',
-        states: {
-          initializing: {
-            on: {
-              didInit: {
-                target: 'initialized',
-                actions: ['executeSendQueue'],
-              },
-              send: {
-                target: 'initializing',
-                actions: ['enqueueSend'],
-              },
-            },
-          },
-          initialized: {
-            on: {
-              send: {
-                target: 'initialized',
-                actions: ['executeSend'],
-              },
-            },
-          },
-        },
-      },
-      options: {
-        actions: {
-          enqueueSend(sendData) {
-            this.sendQueue.push(sendData);
-            return this.initPromise;
-          },
-          executeSendQueue() {
-            let sends = this.sendQueue;
-            let chain = sends.reduce((acc, { eventName, data }) => {
-              return acc.then(() => {
-                return this.send(eventName, data);
-              });
-            }, resolve());
-
-            return chain.then(() => {
-              this.resolveInit();
-            });
-          },
-          executeSend(sendData) {
-            return this._send(sendData);
-          },
-        },
-      },
-      context: this,
-    });
-
-    this.didChangeState = config.didChangeState || noOp;
-    this.context = config.context;
-
-    this.initPromise = new Promise((resolve, reject) => {
-      this.resolveInit = resolve;
-      this.rejectInit = reject;
-    });
-  }
-
-  start() {
-    this.currentState = this.machine.initialState;
-
-    return this._executeActions(this.currentState).then(() => {
-      return this.service.send('didInit');
-    });
+  constructor(config, options, initialContext) {
+    const machine = Machine(config, options, initialContext);
+    this.service = interpret(machine)
+      .onTransition(state => {
+        set(this, 'currentState', state);
+      })
+      .start();
   }
 
   send(eventName, data = {}) {
-    return this.service.send('send', { eventName, data });
-  }
-
-  _send({ eventName, data }) {
-    let newState = this.machine.transition(
-      this.currentState,
-      { type: eventName, data },
-      this.context
-    );
-
-    set(this, 'currentState', newState);
-
-    this.didChangeState(newState);
-
-    return this._executeActions(newState, data);
-  }
-
-  _executeActions(newState, data) {
-    let { actions } = newState;
-
-    let _actions = actions.map(this._functionForAction.bind(this));
-
-    let chain = _actions.reduce((acc, action) => {
-      return acc.then(() => {
-        return action(data, this.context);
-      });
-    }, resolve());
-
-    return chain;
-  }
-
-  _functionForAction(action) {
-    let fn = (action.exec && action.exec.bind(this.context)) || noOp;
-    return fn;
+    this.service.send({ type: eventName, data });
   }
 }

--- a/addon/utils/statechart.js
+++ b/addon/utils/statechart.js
@@ -22,6 +22,6 @@ export default class Statechart {
   }
 
   send(eventName, data = {}) {
-    this.service.send({ type: eventName, data });
+    this.service.send({ type: eventName, ...data });
   }
 }

--- a/addon/utils/statechart.js
+++ b/addon/utils/statechart.js
@@ -1,6 +1,7 @@
 import { Machine, interpret } from 'xstate';
 import { set } from '@ember/object';
 import { later, cancel } from '@ember/runloop';
+import { warn } from '@ember/debug';
 
 export default class Statechart {
   constructor(config, options, initialContext) {
@@ -21,7 +22,24 @@ export default class Statechart {
       .start();
   }
 
-  send(eventName, data = {}) {
-    this.service.send({ type: eventName, ...data });
+  send(event, data = {}) {
+    if (arguments.length === 1) {
+      this._sendEventObject(event);
+    } else {
+      const { type, ...eventData } = data;
+      if (type) {
+        warn(
+          `You passed property \`type\` as part of the data you sent with the event \`${event}\` . This is not supported - \`${event}\` will be used as event name.`,
+          false,
+          { id: 'statecharts.event-object.no-override-type' }
+        );
+      }
+      const eventObject = { ...eventData, type: event };
+      this.service.send(eventObject);
+    }
+  }
+
+  _sendEventObject(eventObject) {
+    this.service.send(eventObject);
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "ember-auto-import": "^1.2.13",
     "ember-cli-babel": "^7.1.2",
-    "xstate": "^4.3.2"
+    "xstate": "^4.4.0"
   },
   "devDependencies": {
     "@ember/optional-features": "^0.6.3",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "ember-load-initializers": "^1.1.0",
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-qunit": "^3.4.1",
+    "ember-qunit-assert-helpers": "^0.2.2",
     "ember-resolver": "^5.0.1",
     "ember-source": "~3.8.0",
     "ember-source-channel-url": "^1.1.0",

--- a/tests/dummy/app/components/x-button/component.js
+++ b/tests/dummy/app/components/x-button/component.js
@@ -82,19 +82,19 @@ export default Component.extend(Evented, {
     },
     {
       actions: {
-        checkDisabled(ctx) {
-          if (ctx.get('disabled')) {
-            ctx.get('statechart').send('disable');
+        checkDisabled(context) {
+          if (context.get('disabled')) {
+            context.get('statechart').send('disable');
           }
         },
-        triggerAction(ctx) {
-          ctx.get('onClickTask').perform();
+        triggerAction(context) {
+          context.get('onClickTask').perform();
         },
-        triggerSuccess(ctx) {
-          ctx.get('onSuccess')();
+        triggerSuccess(context) {
+          context.get('onSuccess')();
         },
-        triggerError(ctx) {
-          ctx.get('onError')();
+        triggerError(context) {
+          context.get('onError')();
         },
       },
     }

--- a/tests/dummy/app/components/x-button/component.js
+++ b/tests/dummy/app/components/x-button/component.js
@@ -82,19 +82,19 @@ export default Component.extend(Evented, {
     },
     {
       actions: {
-        checkDisabled() {
-          if (this.get('disabled')) {
-            this.get('statechart').send('disable');
+        checkDisabled(ctx) {
+          if (ctx.get('disabled')) {
+            ctx.get('statechart').send('disable');
           }
         },
-        triggerAction() {
-          this.get('onClickTask').perform();
+        triggerAction(ctx) {
+          ctx.get('onClickTask').perform();
         },
-        triggerSuccess() {
-          this.get('onSuccess')();
+        triggerSuccess(ctx) {
+          ctx.get('onSuccess')();
         },
-        triggerError() {
-          this.get('onError')();
+        triggerError(ctx) {
+          ctx.get('onError')();
         },
       },
     }

--- a/tests/unit/computed-test.js
+++ b/tests/unit/computed-test.js
@@ -119,8 +119,6 @@ module('Unit | statechart computeds', function(hooks) {
     test('can be used to log the current state of the statechart as a string', async function(assert) {
       let { subject } = this;
 
-      await subject.get('statechart').start();
-
       assert.deepEqual(subject.get('_debug'), '"playerOff"');
 
       await subject.get('statechart').send('power');

--- a/tests/unit/statechart-test.js
+++ b/tests/unit/statechart-test.js
@@ -6,7 +6,7 @@ module('Unit | computed | statechart', function() {
   test('it adds statechart functionality to an ember-object', async function(assert) {
     assert.expect(5);
 
-    let StatechartObject = EmberObject.extend({
+    let subject = EmberObject.extend({
       statechart: statechart(
         {
           initial: 'new',
@@ -23,7 +23,7 @@ module('Unit | computed | statechart', function() {
               },
             },
             foo: {
-              onEntry(data) {
+              onEntry(_ctx, { data }) {
                 assert.deepEqual(data, testData);
               },
             },
@@ -37,15 +37,13 @@ module('Unit | computed | statechart', function() {
           },
         }
       ),
-    });
+    }).create();
 
-    let testData = { wat: 'lol' };
-
-    let subject = StatechartObject.create();
+    const testData = { wat: 'lol' };
 
     assert.equal(get(subject, 'statechart.currentState.value'), 'new');
 
-    await get(subject, 'statechart').send('woot', testData);
+    get(subject, 'statechart').send('woot', testData);
 
     assert.equal(get(subject, 'statechart.currentState.value'), 'foo');
   });

--- a/tests/unit/statechart-test.js
+++ b/tests/unit/statechart-test.js
@@ -73,8 +73,8 @@ module('Unit | computed | statechart', function() {
         },
         {
           guards: {
-            enoughPowerIsAvailable: (context, { data }) => {
-              assert.equal(context.name, 'Tomster', 'accessing context works');
+            enoughPowerIsAvailable: (ctx, { data }) => {
+              assert.equal(ctx.name, 'Tomster', 'accessing context works');
               let { power } = data;
 
               return power > 9000;

--- a/tests/unit/statechart-test.js
+++ b/tests/unit/statechart-test.js
@@ -25,8 +25,8 @@ module('Unit | computed | statechart', function() {
               },
             },
             foo: {
-              onEntry(_ctx, { data }) {
-                assert.deepEqual(data, testData);
+              onEntry(_ctx, { type, ...data }) {
+                assert.deepEqual(data, testData, 'passed data is available in eventObject');
               },
             },
           },
@@ -75,9 +75,8 @@ module('Unit | computed | statechart', function() {
         },
         {
           guards: {
-            enoughPowerIsAvailable: (ctx, { data }) => {
+            enoughPowerIsAvailable: (ctx, { power }) => {
               assert.equal(ctx.name, 'Tomster', 'accessing context works');
-              let { power } = data;
 
               return power > 9000;
             },

--- a/tests/unit/statechart-test.js
+++ b/tests/unit/statechart-test.js
@@ -25,7 +25,7 @@ module('Unit | computed | statechart', function() {
               },
             },
             foo: {
-              onEntry(_ctx, { type, ...data }) {
+              onEntry(_context, { type, ...data }) {
                 assert.deepEqual(data, testData, 'passed data is available in eventObject');
               },
             },
@@ -75,8 +75,8 @@ module('Unit | computed | statechart', function() {
         },
         {
           guards: {
-            enoughPowerIsAvailable: (ctx, { power }) => {
-              assert.equal(ctx.name, 'Tomster', 'accessing context works');
+            enoughPowerIsAvailable: (context, { power }) => {
+              assert.equal(context.name, 'Tomster', 'accessing context works');
 
               return power > 9000;
             },
@@ -130,8 +130,8 @@ module('Unit | computed | statechart', function() {
         },
         {
           actions: {
-            incrementOffCounter(ctx) {
-              ctx.incrementProperty('offCounter');
+            incrementOffCounter(context) {
+              context.incrementProperty('offCounter');
             },
           },
         }

--- a/tests/unit/utils/statechart-test.js
+++ b/tests/unit/utils/statechart-test.js
@@ -85,7 +85,7 @@ module('Unit | Utility | statechart', function(/*hooks*/) {
         },
         {
           actions: {
-            wat(ctx, { data }) {
+            wat(_ctx, { type, ...data }) {
               assert.deepEqual(data, testData, 'data was passed as expected');
             },
           },
@@ -150,12 +150,12 @@ module('Unit | Utility | statechart', function(/*hooks*/) {
         },
         {
           actions: {
-            wat(_ctx, { data }) {
+            wat(_ctx, { type, ...data }) {
               assert.deepEqual(data, testData, 'actionA got passed correct data');
               assert.step('actionA');
             },
-            yo(_ctx, { data }) {
-              assert.deepEqual(data, testData, 'actionA got passed correct data');
+            yo(_ctx, { type, ...data }) {
+              assert.deepEqual(data, testData, 'actionB got passed correct data');
               assert.step('actionB');
             },
           },
@@ -190,13 +190,13 @@ module('Unit | Utility | statechart', function(/*hooks*/) {
             on: {
               woot: 'next',
             },
-            onExit(_ctx, { data }) {
+            onExit(_ctx, { type, ...data }) {
               assert.step('exitState');
               assert.deepEqual(data, someData, 'states can pass data when they transition');
             },
           },
           next: {
-            onEntry(ctx, { data }) {
+            onEntry(ctx, { type, ...data }) {
               assert.step('enterState');
               assert.deepEqual(data, someData, 'states can pass data when they transition');
             },
@@ -267,7 +267,7 @@ module('Unit | Utility | statechart', function(/*hooks*/) {
                 woot: {
                   target: 'next',
                   cond: (ctx, eventObject) => {
-                    let { type, data } = eventObject;
+                    let { type, ...data } = eventObject;
                     assert.equal(type, 'woot', 'eventName is accessible in condition');
                     assert.deepEqual(data, testData, 'passed event data is available in condition');
                     assert.deepEqual(
@@ -397,7 +397,7 @@ module('Unit | Utility | statechart', function(/*hooks*/) {
                 'machine guard functions can access the statecharts context'
               );
 
-              let { type, data: eventData } = eventObject;
+              let { type, ...eventData } = eventObject;
 
               assert.equal(type, 'power', 'eventObject contains name of event that was sent');
               assert.deepEqual(eventData, testData, 'data passed to event is available in guards');
@@ -576,7 +576,7 @@ module('Unit | Utility | statechart', function(/*hooks*/) {
             initial: 'stopped',
             states: {
               stopped: {
-                onEntry(ctx, { data }) {
+                onEntry(ctx, { type, ...data }) {
                   assert.deepEqual(
                     data,
                     testData,
@@ -591,7 +591,7 @@ module('Unit | Utility | statechart', function(/*hooks*/) {
                 },
               },
             },
-            onEntry(ctx, { data }) {
+            onEntry(ctx, { type, ...data }) {
               assert.deepEqual(
                 data,
                 testData,
@@ -793,7 +793,7 @@ module('Unit | Utility | statechart', function(/*hooks*/) {
                   },
                 },
                 pending: {
-                  onEntry(ctx, { data }) {
+                  onEntry(ctx, { type, ...data }) {
                     assert.deepEqual(data, testData, 'passing data works');
                     assert.deepEqual(ctx, testContext, 'context is passed as expected');
                   },
@@ -808,11 +808,11 @@ module('Unit | Utility | statechart', function(/*hooks*/) {
         },
         {
           actions: {
-            handleUploadSuccess(ctx, { data }) {
+            handleUploadSuccess(ctx, { type, ...data }) {
               assert.deepEqual(data, testData, 'passing data works');
               assert.deepEqual(ctx, testContext, 'context is passed as expected');
             },
-            handleInitDownload(ctx, { data }) {
+            handleInitDownload(ctx, { type, ...data }) {
               assert.deepEqual(data, testData, 'passing data works');
               assert.deepEqual(ctx, testContext, 'context is passed');
             },

--- a/tests/unit/utils/statechart-test.js
+++ b/tests/unit/utils/statechart-test.js
@@ -1,5 +1,6 @@
 import Statechart from 'dummy/utils/statechart';
 import { module, test } from 'qunit';
+import { timeout } from 'ember-concurrency';
 
 module('Unit | Utility | statechart', function(/*hooks*/) {
   module('#send', function() {
@@ -860,6 +861,87 @@ module('Unit | Utility | statechart', function(/*hooks*/) {
         },
         'parallel states have expected end states'
       );
+    });
+  });
+
+  module('delays', function() {
+    test('delays work as expected', async function(assert) {
+      assert.expect(7);
+
+      const statechart = new Statechart(
+        {
+          initial: 'powerOff',
+          states: {
+            powerOff: {
+              on: {
+                POWER: 'powerOn',
+              },
+            },
+            powerOn: {
+              initial: 'red',
+              on: {
+                POWER: 'powerOff',
+              },
+              states: {
+                red: {
+                  after: {
+                    LIGHT_DELAY: 'yellow',
+                  },
+                },
+                yellow: {
+                  after: {
+                    50: 'green',
+                  },
+                },
+                green: {
+                  after: {
+                    100: 'red',
+                  },
+                },
+              },
+            },
+          },
+        },
+        {
+          delays: {
+            LIGHT_DELAY: 200,
+          },
+        }
+      );
+
+      assert.equal(statechart.currentState.value, 'powerOff');
+
+      statechart.send('POWER');
+
+      await timeout(100);
+
+      // transition will happen after 200ms not 100ms
+      assert.deepEqual(statechart.currentState.value, { powerOn: 'red' });
+
+      await timeout(105);
+
+      // 205ms elapsed we should be in yellow
+      assert.deepEqual(statechart.currentState.value, { powerOn: 'yellow' });
+
+      await timeout(25);
+
+      // 230ms we should still be in yellow
+      assert.deepEqual(statechart.currentState.value, { powerOn: 'yellow' });
+
+      await timeout(70);
+
+      // 300ms we should be in green by now
+      assert.deepEqual(statechart.currentState.value, { powerOn: 'green' });
+
+      await timeout(60);
+
+      // 360ms we should be back in red
+      assert.deepEqual(statechart.currentState.value, { powerOn: 'red' });
+
+      // turn of light
+      statechart.send('POWER');
+
+      assert.deepEqual(statechart.currentState.value, 'powerOff');
     });
   });
 });

--- a/tests/unit/utils/statechart-test.js
+++ b/tests/unit/utils/statechart-test.js
@@ -86,7 +86,7 @@ module('Unit | Utility | statechart', function(/*hooks*/) {
           },
           {
             actions: {
-              wat(_ctx, { type, ...data }) {
+              wat(_context, { type, ...data }) {
                 assert.deepEqual(data, testData, 'data was passed as expected');
               },
             },
@@ -118,7 +118,7 @@ module('Unit | Utility | statechart', function(/*hooks*/) {
           },
           {
             actions: {
-              wat(_ctx, { type, ...data }) {
+              wat(_context, { type, ...data }) {
                 assert.deepEqual(data, testData, 'data was passed as expected');
               },
             },
@@ -153,7 +153,7 @@ module('Unit | Utility | statechart', function(/*hooks*/) {
           },
           {
             actions: {
-              wat(_ctx, { type, ...data }) {
+              wat(_context, { type, ...data }) {
                 assert.equal(type, 'woot', 'overriding of `type` does not work');
                 assert.deepEqual(data, { name: 'Tomster' }, 'data was passed as expected');
                 assert.expectWarning(
@@ -223,11 +223,11 @@ module('Unit | Utility | statechart', function(/*hooks*/) {
         },
         {
           actions: {
-            wat(_ctx, { type, ...data }) {
+            wat(_context, { type, ...data }) {
               assert.deepEqual(data, testData, 'actionA got passed correct data');
               assert.step('actionA');
             },
-            yo(_ctx, { type, ...data }) {
+            yo(_context, { type, ...data }) {
               assert.deepEqual(data, testData, 'actionB got passed correct data');
               assert.step('actionB');
             },
@@ -263,13 +263,13 @@ module('Unit | Utility | statechart', function(/*hooks*/) {
             on: {
               woot: 'next',
             },
-            onExit(_ctx, { type, ...data }) {
+            onExit(_context, { type, ...data }) {
               assert.step('exitState');
               assert.deepEqual(data, someData, 'states can pass data when they transition');
             },
           },
           next: {
-            onEntry(ctx, { type, ...data }) {
+            onEntry(context, { type, ...data }) {
               assert.step('enterState');
               assert.deepEqual(data, someData, 'states can pass data when they transition');
             },
@@ -308,8 +308,8 @@ module('Unit | Utility | statechart', function(/*hooks*/) {
         },
         {
           actions: {
-            test(ctx) {
-              assert.deepEqual(ctx, testContext, 'context is accessible in action handlers');
+            test(context) {
+              assert.deepEqual(context, testContext, 'context is accessible in action handlers');
             },
           },
         },
@@ -339,12 +339,12 @@ module('Unit | Utility | statechart', function(/*hooks*/) {
               on: {
                 woot: {
                   target: 'next',
-                  cond: (ctx, eventObject) => {
+                  cond: (context, eventObject) => {
                     let { type, ...data } = eventObject;
                     assert.equal(type, 'woot', 'eventName is accessible in condition');
                     assert.deepEqual(data, testData, 'passed event data is available in condition');
                     assert.deepEqual(
-                      ctx,
+                      context,
                       testContext,
                       "the statechart's context is available in condition"
                     );
@@ -582,11 +582,11 @@ module('Unit | Utility | statechart', function(/*hooks*/) {
               initial: 'stopped',
               states: {
                 stopped: {
-                  onEntry(ctx) {
-                    assert.deepEqual(ctx, testContext, 'context is available as expected');
+                  onEntry(context) {
+                    assert.deepEqual(context, testContext, 'context is available as expected');
                   },
-                  onExit(ctx) {
-                    assert.equal(ctx.name, 'lol');
+                  onExit(context) {
+                    assert.equal(context.name, 'lol');
                   },
                   on: {
                     play: {
@@ -609,8 +609,8 @@ module('Unit | Utility | statechart', function(/*hooks*/) {
         },
         {
           actions: {
-            testTestContext(ctx) {
-              assert.deepEqual(ctx, testContext);
+            testTestContext(context) {
+              assert.deepEqual(context, testContext);
             },
           },
         }
@@ -649,7 +649,7 @@ module('Unit | Utility | statechart', function(/*hooks*/) {
             initial: 'stopped',
             states: {
               stopped: {
-                onEntry(ctx, { type, ...data }) {
+                onEntry(context, { type, ...data }) {
                   assert.deepEqual(
                     data,
                     testData,
@@ -664,7 +664,7 @@ module('Unit | Utility | statechart', function(/*hooks*/) {
                 },
               },
             },
-            onEntry(ctx, { type, ...data }) {
+            onEntry(context, { type, ...data }) {
               assert.deepEqual(
                 data,
                 testData,
@@ -866,9 +866,9 @@ module('Unit | Utility | statechart', function(/*hooks*/) {
                   },
                 },
                 pending: {
-                  onEntry(ctx, { type, ...data }) {
+                  onEntry(context, { type, ...data }) {
                     assert.deepEqual(data, testData, 'passing data works');
-                    assert.deepEqual(ctx, testContext, 'context is passed as expected');
+                    assert.deepEqual(context, testContext, 'context is passed as expected');
                   },
                   on: {
                     DOWNLOAD_COMPLETE: 'success',
@@ -881,13 +881,13 @@ module('Unit | Utility | statechart', function(/*hooks*/) {
         },
         {
           actions: {
-            handleUploadSuccess(ctx, { type, ...data }) {
+            handleUploadSuccess(context, { type, ...data }) {
               assert.deepEqual(data, testData, 'passing data works');
-              assert.deepEqual(ctx, testContext, 'context is passed as expected');
+              assert.deepEqual(context, testContext, 'context is passed as expected');
             },
-            handleInitDownload(ctx, { type, ...data }) {
+            handleInitDownload(context, { type, ...data }) {
               assert.deepEqual(data, testData, 'passing data works');
-              assert.deepEqual(ctx, testContext, 'context is passed');
+              assert.deepEqual(context, testContext, 'context is passed');
             },
           },
         }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8663,7 +8663,7 @@ xmlhttprequest-ssl@~1.5.4:
   version "1.5.5"
   resolved "https://registry.yarnpkg.com/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.5.tgz#c2876b06168aadc40e57d97e81191ac8f4398b3e"
 
-xstate@^4.3.2:
+xstate@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/xstate/-/xstate-4.4.0.tgz#0daedbdc49313357413546de04fafa0dba7aa0ce"
   integrity sha512-MS638X5zCzEAZA/UOW9fUHSg4xAGfiHFkGMjtU5j/gmb1PtGBAVImv0iWqRZNwVqTALxxtQz655BVyNSNz2ThA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -999,6 +999,13 @@ amd-name-resolver@0.0.7:
   dependencies:
     ensure-posix-path "^1.0.1"
 
+amd-name-resolver@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/amd-name-resolver/-/amd-name-resolver-1.2.0.tgz#fc41b3848824b557313897d71f8d5a0184fbe679"
+  integrity sha512-hlSTWGS1t6/xq5YCed7YALg7tKZL3rkl7UwEZ/eCIkn8JxmM6fU6Qs/1hwtjQqfuYxlffuUcgYEm0f5xP4YKaA==
+  dependencies:
+    ensure-posix-path "^1.0.1"
+
 amd-name-resolver@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/amd-name-resolver/-/amd-name-resolver-1.2.1.tgz#cea40abff394268307df647ce340c83eda6e9cfc"
@@ -1375,7 +1382,7 @@ babel-plugin-debug-macros@^0.1.10, babel-plugin-debug-macros@^0.1.11:
   dependencies:
     semver "^5.3.0"
 
-babel-plugin-debug-macros@^0.2.0:
+babel-plugin-debug-macros@^0.2.0, babel-plugin-debug-macros@^0.2.0-beta.6:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-debug-macros/-/babel-plugin-debug-macros-0.2.0.tgz#0120ac20ce06ccc57bf493b667cf24b85c28da7a"
   integrity sha512-Wpmw4TbhR3Eq2t3W51eBAQSdKlr+uAyF0GI4GtPfMCD12Y4cIdpKC9l0RjNTH/P9isFypSqqewMPm7//fnZlNA==
@@ -1395,7 +1402,7 @@ babel-plugin-ember-modules-api-polyfill@^2.3.0:
   dependencies:
     ember-rfc176-data "^0.3.0"
 
-babel-plugin-ember-modules-api-polyfill@^2.8.0:
+babel-plugin-ember-modules-api-polyfill@^2.6.0, babel-plugin-ember-modules-api-polyfill@^2.8.0:
   version "2.8.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-2.8.0.tgz#70244800f750bf1c9f380910c1b2eed1db80ab4a"
   integrity sha512-3dlBH92qx8so2pRoks73+gwnuX97d0ajirOr96GwTZMnZxFzVR02c/PQbKWBcxpPqoL8CJSE2onuWM8PWezhOQ==
@@ -1635,7 +1642,7 @@ babel-plugin-transform-strict-mode@^6.24.1:
     babel-runtime "^6.22.0"
     babel-types "^6.24.1"
 
-babel-polyfill@^6.16.0:
+babel-polyfill@^6.16.0, babel-polyfill@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-polyfill/-/babel-polyfill-6.26.0.tgz#379937abc67d7895970adc621f284cd966cf2153"
   dependencies:
@@ -1675,6 +1682,42 @@ babel-preset-env@^1.5.1:
     babel-plugin-transform-exponentiation-operator "^6.22.0"
     babel-plugin-transform-regenerator "^6.22.0"
     browserslist "^2.1.2"
+    invariant "^2.2.2"
+    semver "^5.3.0"
+
+babel-preset-env@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/babel-preset-env/-/babel-preset-env-1.7.0.tgz#dea79fa4ebeb883cd35dab07e260c1c9c04df77a"
+  integrity sha512-9OR2afuKDneX2/q2EurSftUYM0xGu4O2D9adAhVfADDhrYDaxXV0rBbevVYoY9n6nyX1PmQW/0jtpJvUNr9CHg==
+  dependencies:
+    babel-plugin-check-es2015-constants "^6.22.0"
+    babel-plugin-syntax-trailing-function-commas "^6.22.0"
+    babel-plugin-transform-async-to-generator "^6.22.0"
+    babel-plugin-transform-es2015-arrow-functions "^6.22.0"
+    babel-plugin-transform-es2015-block-scoped-functions "^6.22.0"
+    babel-plugin-transform-es2015-block-scoping "^6.23.0"
+    babel-plugin-transform-es2015-classes "^6.23.0"
+    babel-plugin-transform-es2015-computed-properties "^6.22.0"
+    babel-plugin-transform-es2015-destructuring "^6.23.0"
+    babel-plugin-transform-es2015-duplicate-keys "^6.22.0"
+    babel-plugin-transform-es2015-for-of "^6.23.0"
+    babel-plugin-transform-es2015-function-name "^6.22.0"
+    babel-plugin-transform-es2015-literals "^6.22.0"
+    babel-plugin-transform-es2015-modules-amd "^6.22.0"
+    babel-plugin-transform-es2015-modules-commonjs "^6.23.0"
+    babel-plugin-transform-es2015-modules-systemjs "^6.23.0"
+    babel-plugin-transform-es2015-modules-umd "^6.23.0"
+    babel-plugin-transform-es2015-object-super "^6.22.0"
+    babel-plugin-transform-es2015-parameters "^6.23.0"
+    babel-plugin-transform-es2015-shorthand-properties "^6.22.0"
+    babel-plugin-transform-es2015-spread "^6.22.0"
+    babel-plugin-transform-es2015-sticky-regex "^6.22.0"
+    babel-plugin-transform-es2015-template-literals "^6.22.0"
+    babel-plugin-transform-es2015-typeof-symbol "^6.23.0"
+    babel-plugin-transform-es2015-unicode-regex "^6.22.0"
+    babel-plugin-transform-exponentiation-operator "^6.22.0"
+    babel-plugin-transform-regenerator "^6.22.0"
+    browserslist "^3.2.6"
     invariant "^2.2.2"
     semver "^5.3.0"
 
@@ -1932,6 +1975,22 @@ broccoli-babel-transpiler@^6.1.2:
     rsvp "^4.8.2"
     workerpool "^2.3.0"
 
+broccoli-babel-transpiler@^6.5.0:
+  version "6.5.1"
+  resolved "https://registry.yarnpkg.com/broccoli-babel-transpiler/-/broccoli-babel-transpiler-6.5.1.tgz#a4afc8d3b59b441518eb9a07bd44149476e30738"
+  integrity sha512-w6GcnkxvHcNCte5FcLGEG1hUdQvlfvSN/6PtGWU/otg69Ugk8rUk51h41R0Ugoc+TNxyeFG1opRt2RlA87XzNw==
+  dependencies:
+    babel-core "^6.26.0"
+    broccoli-funnel "^2.0.1"
+    broccoli-merge-trees "^2.0.0"
+    broccoli-persistent-filter "^1.4.3"
+    clone "^2.0.0"
+    hash-for-dep "^1.2.3"
+    heimdalljs-logger "^0.1.7"
+    json-stable-stringify "^1.0.0"
+    rsvp "^4.8.2"
+    workerpool "^2.3.0"
+
 broccoli-babel-transpiler@^7.1.1:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/broccoli-babel-transpiler/-/broccoli-babel-transpiler-7.1.2.tgz#fb5d6f8b9a805627ac3f2914ac9d86e82ca2413b"
@@ -2056,7 +2115,7 @@ broccoli-debug@^0.6.2, broccoli-debug@^0.6.4, broccoli-debug@^0.6.5:
     symlink-or-copy "^1.1.8"
     tree-sync "^1.2.2"
 
-broccoli-filter@^1.2.2, broccoli-filter@^1.2.3:
+broccoli-filter@^1.0.1, broccoli-filter@^1.2.2, broccoli-filter@^1.2.3:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/broccoli-filter/-/broccoli-filter-1.3.0.tgz#71e3a8e32a17f309e12261919c5b1006d6766de6"
   dependencies:
@@ -2433,6 +2492,14 @@ browserslist@^2.1.2:
     caniuse-lite "^1.0.30000792"
     electron-to-chromium "^1.3.30"
 
+browserslist@^3.2.6:
+  version "3.2.8"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-3.2.8.tgz#b0005361d6471f0f5952797a76fc985f1f978fc6"
+  integrity sha512-WHVocJYavUwVgVViC0ORikPHQquXwVh939TaelZ4WDqpWgTX/FsGhl/+P4qBUAGcRvtOgDgC+xftNWWp2RUTAQ==
+  dependencies:
+    caniuse-lite "^1.0.30000844"
+    electron-to-chromium "^1.3.47"
+
 browserslist@^4.3.4:
   version "4.3.7"
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.3.7.tgz#f1de479a6466ea47a0a26dcc725e7504817e624a"
@@ -2577,6 +2644,11 @@ can-symlink@^1.0.0:
 caniuse-lite@^1.0.30000792:
   version "1.0.30000835"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000835.tgz#517c4d3807a8527b0cbce1d84c85d4487f877268"
+
+caniuse-lite@^1.0.30000844:
+  version "1.0.30000957"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000957.tgz#fb1026bf184d7d62c685205358c3b24b9e29f7b3"
+  integrity sha512-8wxNrjAzyiHcLXN/iunskqQnJquQQ6VX8JHfW5kLgAPRSiSuKZiNfmIkP5j7jgyXqAQBSoXyJxfnbCFS0ThSiQ==
 
 caniuse-lite@^1.0.30000925:
   version "1.0.30000926"
@@ -3300,6 +3372,11 @@ electron-to-chromium@^1.3.30:
   version "1.3.45"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.45.tgz#458ac1b1c5c760ce8811a16d2bfbd97ec30bafb8"
 
+electron-to-chromium@^1.3.47:
+  version "1.3.124"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.124.tgz#861fc0148748a11b3e5ccebdf8b795ff513fa11f"
+  integrity sha512-glecGr/kFdfeXUHOHAWvGcXrxNU+1wSO/t5B23tT1dtlvYB26GY8aHzZSWD7HqhqC800Lr+w/hQul6C5AF542w==
+
 electron-to-chromium@^1.3.96:
   version "1.3.96"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.96.tgz#25770ec99b8b07706dedf3a5f43fa50cb54c4f9a"
@@ -3377,6 +3454,25 @@ ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.0.0-beta.7, ember-cli-babel@^6
     clone "^2.0.0"
     ember-cli-version-checker "^2.1.0"
     semver "^5.4.1"
+
+ember-cli-babel@^6.9.0:
+  version "6.18.0"
+  resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-6.18.0.tgz#3f6435fd275172edeff2b634ee7b29ce74318957"
+  integrity sha512-7ceC8joNYxY2wES16iIBlbPSxwKDBhYwC8drU3ZEvuPDMwVv1KzxCNu1fvxyFEBWhwaRNTUxSCsEVoTd9nosGA==
+  dependencies:
+    amd-name-resolver "1.2.0"
+    babel-plugin-debug-macros "^0.2.0-beta.6"
+    babel-plugin-ember-modules-api-polyfill "^2.6.0"
+    babel-plugin-transform-es2015-modules-amd "^6.24.0"
+    babel-polyfill "^6.26.0"
+    babel-preset-env "^1.7.0"
+    broccoli-babel-transpiler "^6.5.0"
+    broccoli-debug "^0.6.4"
+    broccoli-funnel "^2.0.0"
+    broccoli-source "^1.1.0"
+    clone "^2.0.0"
+    ember-cli-version-checker "^2.1.2"
+    semver "^5.5.0"
 
 ember-cli-babel@^7.1.2, ember-cli-babel@^7.2.0:
   version "7.7.3"
@@ -3720,6 +3816,14 @@ ember-maybe-import-regenerator@^0.1.5, ember-maybe-import-regenerator@^0.1.6:
     broccoli-merge-trees "^1.0.0"
     ember-cli-babel "^6.0.0-beta.4"
     regenerator-runtime "^0.9.5"
+
+ember-qunit-assert-helpers@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/ember-qunit-assert-helpers/-/ember-qunit-assert-helpers-0.2.2.tgz#6fec8a33fd0d2c3fb6202f849291a309581727a4"
+  integrity sha512-P5eAqD753+p/qEeBi6OGpl2EzRxx8O9dUnr6HgyxU9fqQsSNQkJNGZ+ajbtePI8oMDGm+X7uOnf1+BgQ7eJ7qg==
+  dependencies:
+    broccoli-filter "^1.0.1"
+    ember-cli-babel "^6.9.0"
 
 ember-qunit@^3.4.1:
   version "3.5.3"


### PR DESCRIPTION
Xstate now comes with [interpreter functionality](https://xstate.js.org/docs/guides/interpretation.html#interpreter) out of the box. Making use of xstate's interpreter makes sure users of `ember-statecharts` can use all of xstate's functionality, e.g. [history-state](https://xstate.js.org/docs/guides/history.html) wasn't supported before nor were new features like [activities](https://xstate.js.org/docs/guides/activities.html) or [delays](https://xstate.js.org/docs/guides/delays.html#delayed-transitions). By relying on xstate's native interpreter we make sure we get new features xstate implements for free in the future.

Questions regarding this PR:

- ~~we are not using Ember's runloop for the [interpreter's clock](https://xstate.js.org/docs/guides/delays.html#interpretation)-functionality. We most likely want to use the runloop though as it will make certain things easier to test.~~
- this PR unfortunately changes the statechart api for `ember-statecharts` - we are now not binding `this` of actions to the `Ember.Object` that is implementing the statechart. This will create the need for users to update their statechart configurations if they rely on this behavior. The benefit is that `actions` and `guards` now behave the same way which is easier to get for new users.
- ~~this PR keeps the custom `send`-interface on statecharts - this format is specific to `ember-statecharts` and diverges from the way developers can send event's with xstate. xstate allows their users to send events by [sending an `event-object`](https://xstate.js.org/docs/guides/events.html#sending-events). I feel like the way `ember-statecharts` lets users send event-data - i.e. `statechart.send('EVENTNAME', { woot: "fubar" })` and then making the event-data accessible in actions via the data-property is more conventional - i.e. `wat(ctx, { data: { woot } }) => console.log(woot)`. If we feel this is unecessary and we want to mirror xstate's `send` that's fine for me as well. People will need to update their statechart configurations anyway so we could also force them to follow xstate as closely as possible from now on.~~
- ~~I added prettier to the addon to make sure code stays consistent. This obviously should have gone into a separate PR - I can pull changes out and do a follow up PR if need be~~
- `statechart#send` now aligns with what xstate does (and will do from 4.5 on) - i.e. you can either pass a string, an event-object (`{ type: <event-name>, ...data }`) or pass two params `eventName`, and additional event-data. 