### PR TITLE
call willDestroy with correct context

### DIFF
--- a/addon/computed.js
+++ b/addon/computed.js
@@ -7,7 +7,7 @@ function decorateStopInterpreterOnDestroy(destroyFn, service) {
   return function() {
     service.stop();
 
-    destroyFn(...arguments);
+    destroyFn.apply(this, ...arguments);
   };
 }
 

--- a/tests/unit/statechart-test.js
+++ b/tests/unit/statechart-test.js
@@ -136,6 +136,12 @@ module('Unit | computed | statechart', function() {
           },
         }
       ),
+
+      willDestroy() {
+        this._super(...arguments);
+
+        assert.step('willDestroy hook is called correctly');
+      },
     }).create();
 
     assert.equal(get(subject, 'statechart.currentState.value'), 'powerOff');
@@ -149,5 +155,7 @@ module('Unit | computed | statechart', function() {
 
     // will fail with `calling set on destroyed object` if  this doesn't work
     await run(() => subject.destroy());
+
+    assert.verifySteps(['willDestroy hook is called correctly']);
   });
 });


### PR DESCRIPTION
After upgrading, the a custom `willDestroy` hook failed since `this` within `willDestroy` evaluated to `undefined` 😱 