### PR TITLE
Add `withMachine` constructor

### DIFF
--- a/addon/computed.js
+++ b/addon/computed.js
@@ -1,5 +1,5 @@
 import { computed, get } from '@ember/object';
-import { matchesState } from 'xstate';
+import { StateNode, matchesState } from 'xstate';
 import { A, makeArray } from '@ember/array';
 import Statechart from './utils/statechart';
 
@@ -27,11 +27,16 @@ function debugState(statechartPropertyName = 'statechart') {
   });
 }
 
-function statechart(config, options) {
+function statechart(configOrMachine, options) {
   return computed(function() {
     const initialContext = this;
 
-    const statechart = new Statechart(config, options, initialContext);
+    let statechart;
+    if (configOrMachine instanceof StateNode) {
+      statechart = Statechart.withMachine(configOrMachine, initialContext);
+    } else {
+      statechart = new Statechart(configOrMachine, options, initialContext);
+    }
 
     this.willDestroy = decorateStopInterpreterOnDestroy(this.willDestroy, statechart.service);
 

--- a/addon/utils/statechart.js
+++ b/addon/utils/statechart.js
@@ -5,7 +5,22 @@ import { warn } from '@ember/debug';
 
 export default class Statechart {
   constructor(config, options, initialContext) {
+    if (arguments.length === 0) {
+      return;
+    }
     const machine = Machine(config, options, initialContext);
+    this._setupMachine(machine);
+  }
+
+  static withMachine(machine, initialContext) {
+    const statechart = new Statechart();
+    if (initialContext) {
+      statechart._setupMachine(machine.withContext(initialContext));
+    }
+    return statechart;
+  }
+
+  _setupMachine(machine) {
     this.service = interpret(machine, {
       clock: {
         setTimeout: (fn, ms) => {


### PR DESCRIPTION
For full type safety when using ember-statecharts/xstate I would need to provide 2 new types for the xstate machine as described here: https://xstate.js.org/docs/guides/typescript.html#using-typescript
1. StateSchema
2. Events that the machine handles

To do this I figured out that I'll need to use the `Machine` constructor as defined in this example:
```ts
const lightMachine = Machine<LightContext, LightStateSchema, LightEvent>({
  // ...
});
```

To support this behavior, I added a second constructor method `withMachine` which you can directly pass a Machine instead of `{ config, options }` object. It uses the `Machine.withContext` api from xstate to apply the context after creation:
https://xstate.js.org/docs/guides/communication.html#invoking-machines

So there would be 2 ways to initialize a statechart:
```ts
@statechart({ /* config */ }, { /* options */ })
myStatechart!: any;
```
```ts
import { Machine } from 'xstate';

@statechart(/* xstate Machine */)
myStatechart!: any;
```