### PR TITLE
feat: add `.update`-hook for handling usable updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,29 +106,15 @@ export default class QuickstartButton extends Component {
     return this.args.onClick || noop;
   }
 
-  get onSuccess() {
-    return this.args.onSuccess || noop;
-  }
-
-  get onError() {
-    return this.args.onError || noop;
-  }
-
   @use statechart = useMachine(buttonMachine)
     .withContext({
-      component: this,
+      disabled: this.args.disabled
     })
     .withConfig({
       actions: {
-        handleSubmit({ component }) {
-          component.handleSubmitTask.perform();
-        },
-        handleSuccess({ component }) {
-          component.onSuccess();
-        },
-        handleError({ component }) {
-          component.onError();
-        },
+        handleSubmit: this.performSubmitTask,
+        handleSuccess: this.onSuccess,
+        handleError: this.onError,
       },
     });
 
@@ -152,6 +138,21 @@ export default class QuickstartButton extends Component {
   @action
   handleClick() {
     this.statechart.send('SUBMIT');
+  }
+
+  @action
+  onSuccess(_context, { result }) {
+    return this.args.onSuccess(result) || noop();
+  }
+
+  @action
+  onError(_context, { error }) {
+    return this.args.onError(error) || noop();
+  }
+
+  @action
+  performSubmitTask() {
+    this.handleSubmitTask.perform();
   }
 }
 ```

--- a/tests/dummy/app/components/counter-restart.hbs
+++ b/tests/dummy/app/components/counter-restart.hbs
@@ -1,0 +1,34 @@
+<div class="docs">
+  Counter Count: {{this.statechart.state.context.count}}
+</div>
+<div class="docs-flex docs-justify-between">
+  <div>
+    {{#if this.isActive}}
+      <UiButton
+        {{on "click" this.deactivate}}
+      >
+        Deactivate
+      </UiButton>
+    {{else}}
+      <UiButton
+        {{on "click" this.activate}}
+      >
+        Activate
+      </UiButton>
+    {{/if}}
+  </div>
+  <div>
+    <UiButton
+      class="{{if this.isDisabled "docs-cursor-not-allowed docs-opacity-50"}}"
+      {{on "click" this.decrement}}
+    >
+      -
+    </UiButton>
+    <UiButton
+      class="{{if this.isDisabled "docs-cursor-not-allowed docs-opacity-50"}}"
+      {{on "click" this.increment}}
+    >
+      +
+    </UiButton>
+  </div>
+</div>

--- a/tests/dummy/app/components/counter-restart.js
+++ b/tests/dummy/app/components/counter-restart.js
@@ -1,0 +1,41 @@
+// BEGIN-SNIPPET counter-update-restart.js
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { use } from 'ember-usable';
+import { useMachine, matchesState } from 'ember-statecharts';
+import CounterMachine from '../machines/counter-machine';
+
+export default class CounterComponent extends Component {
+  @use statechart = useMachine(CounterMachine)
+    .withContext({
+      count: this.args.count,
+    })
+    .update(({ restart }) => restart());
+
+  @matchesState('active')
+  isActive;
+
+  @matchesState('inactive')
+  isDisabled;
+
+  @action
+  decrement() {
+    this.statechart.send('DECREMENT');
+  }
+
+  @action
+  increment() {
+    this.statechart.send('INCREMENT');
+  }
+
+  @action
+  activate() {
+    this.statechart.send('ACTIVATE');
+  }
+
+  @action
+  deactivate() {
+    this.statechart.send('DEACTIVATE');
+  }
+}
+// END-SNIPPET

--- a/tests/dummy/app/components/counter.hbs
+++ b/tests/dummy/app/components/counter.hbs
@@ -1,0 +1,34 @@
+<div class="docs">
+  Counter Count: {{this.statechart.state.context.count}}
+</div>
+<div class="docs-flex docs-justify-between">
+  <div>
+    {{#if this.isActive}}
+      <UiButton
+        {{on "click" this.deactivate}}
+      >
+        Deactivate
+      </UiButton>
+    {{else}}
+      <UiButton
+        {{on "click" this.activate}}
+      >
+        Activate
+      </UiButton>
+    {{/if}}
+  </div>
+  <div>
+    <UiButton
+      class="{{if this.isDisabled "docs-cursor-not-allowed docs-opacity-50"}}"
+      {{on "click" this.decrement}}
+    >
+      -
+    </UiButton>
+    <UiButton
+      class="{{if this.isDisabled "docs-cursor-not-allowed docs-opacity-50"}}"
+      {{on "click" this.increment}}
+    >
+      +
+    </UiButton>
+  </div>
+</div>

--- a/tests/dummy/app/components/counter.js
+++ b/tests/dummy/app/components/counter.js
@@ -1,0 +1,41 @@
+// BEGIN-SNIPPET counter-update-event.js
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { use } from 'ember-usable';
+import { useMachine, matchesState } from 'ember-statecharts';
+import CounterMachine from '../machines/counter-machine';
+
+export default class CounterComponent extends Component {
+  @use statechart = useMachine(CounterMachine)
+    .withContext({
+      count: this.args.count,
+    })
+    .update(({ send, context }) => send('RESET_COUNT', { count: context.count }));
+
+  @matchesState('active')
+  isActive;
+
+  @matchesState('inactive')
+  isDisabled;
+
+  @action
+  decrement() {
+    this.statechart.send('DECREMENT');
+  }
+
+  @action
+  increment() {
+    this.statechart.send('INCREMENT');
+  }
+
+  @action
+  activate() {
+    this.statechart.send('ACTIVATE');
+  }
+
+  @action
+  deactivate() {
+    this.statechart.send('DEACTIVATE');
+  }
+}
+// END-SNIPPET

--- a/tests/dummy/app/components/quickstart-button-refined.hbs
+++ b/tests/dummy/app/components/quickstart-button-refined.hbs
@@ -7,8 +7,6 @@
     {{if this.showAsDisabled "docs-cursor-not-allowed docs-opacity-50"}}
   "
   {{on "click" this.handleClick}}
-  {{did-insert this.handleDisabled @disabled}}
-  {{did-update this.handleDisabled @disabled}}
   disabled={{this.isDisabled}}
   ...attributes
 >

--- a/tests/dummy/app/components/quickstart-button.js
+++ b/tests/dummy/app/components/quickstart-button.js
@@ -13,31 +13,13 @@ export default class QuickstartButton extends Component {
     return this.args.onClick || noop;
   }
 
-  get onSuccess() {
-    return this.args.onSuccess || noop;
-  }
-
-  get onError() {
-    return this.args.onError || noop;
-  }
-
-  @use statechart = useMachine(quickstartButtonMachine)
-    .withContext({
-      component: this,
-    })
-    .withConfig({
-      actions: {
-        handleSubmit({ component }) {
-          component.handleSubmitTask.perform();
-        },
-        handleSuccess({ component }) {
-          component.onSuccess();
-        },
-        handleError({ component }) {
-          component.onError();
-        },
-      },
-    });
+  @use statechart = useMachine(quickstartButtonMachine).withConfig({
+    actions: {
+      handleSubmit: this.performSubmitTask,
+      handleSuccess: this.onSuccess,
+      handleError: this.onError,
+    },
+  });
 
   @matchesState('busy')
   isBusy;
@@ -59,6 +41,21 @@ export default class QuickstartButton extends Component {
   @action
   handleClick() {
     this.statechart.send('SUBMIT');
+  }
+
+  @action
+  onSuccess(_context, { result }) {
+    return this.args.onSuccess(result) || noop();
+  }
+
+  @action
+  onError(_context, { error }) {
+    return this.args.onError(error) || noop();
+  }
+
+  @action
+  performSubmitTask() {
+    this.handleSubmitTask.perform();
   }
 }
 // END-SNIPPET

--- a/tests/dummy/app/controllers/docs/statecharts.js
+++ b/tests/dummy/app/controllers/docs/statecharts.js
@@ -1,0 +1,17 @@
+import Controller from '@ember/controller';
+import { action } from '@ember/object';
+
+export default class StatechartsController extends Controller {
+  counterCount = 0;
+  count = 0;
+
+  @action
+  updateCount({ target: { value } }) {
+    this.set('count', value);
+  }
+
+  @action
+  syncCounterCount() {
+    this.set('counterCount', +this.count);
+  }
+}

--- a/tests/dummy/app/machines/counter-machine.js
+++ b/tests/dummy/app/machines/counter-machine.js
@@ -1,0 +1,48 @@
+// BEGIN-SNIPPET counter-machine.js
+import { Machine, assign } from 'xstate';
+
+export default Machine({
+  id: 'counterMachine',
+  initial: 'inactive',
+  context: {
+    count: 0,
+  },
+  on: {
+    RESET_COUNT: {
+      actions: [
+        assign({
+          count: (_context, { count }) => count,
+        }),
+      ],
+    },
+  },
+  states: {
+    inactive: {
+      on: {
+        ACTIVATE: 'active',
+      },
+    },
+    active: {
+      on: {
+        DEACTIVATE: 'inactive',
+        INCREMENT: {
+          target: 'active',
+          actions: [
+            assign({
+              count: (context) => context.count + 1,
+            }),
+          ],
+        },
+        DECREMENT: {
+          target: 'active',
+          actions: [
+            assign({
+              count: (context) => context.count - 1,
+            }),
+          ],
+        },
+      },
+    },
+  },
+});
+// END-SNIPPET

--- a/tests/dummy/app/machines/quickstart-button-refined.js
+++ b/tests/dummy/app/machines/quickstart-button-refined.js
@@ -10,8 +10,7 @@ export default Machine(
         states: {
           unknown: {
             on: {
-              ENABLE: 'enabled',
-              DISABLE: 'disabled',
+              '': [{ target: 'enabled', cond: 'isEnabled' }, { target: 'disabled' }],
             },
           },
           enabled: {
@@ -68,19 +67,13 @@ export default Machine(
   },
   {
     actions: {
-      handleSubmit(context) {
-        context.handleSubmitTask.perform();
-      },
-      handleSuccess(context) {
-        context.onSuccess();
-      },
-      handleError(context) {
-        context.onError();
-      },
+      handleSubmit() {},
+      handleSuccess() {},
+      handleError() {},
     },
     guards: {
       isEnabled(context) {
-        return !context.isDisabled;
+        return !context.disabled;
       },
     },
   }

--- a/tests/dummy/app/templates/docs/statecharts.md
+++ b/tests/dummy/app/templates/docs/statecharts.md
@@ -544,6 +544,82 @@ states:
 @matchesState('idle')
 ```
 
+## `.update` - Reacting to changes to `useMachine`
+
+When args or state passed to `useMachine`, `withConfig` or `withContext` change
+users are able to react to the change without needing to use
+[@ember/render-modifiers](https://github.com/emberjs/ember-render-modifiers) or
+[ember-render-helpers](https://github.com/buschtoens/ember-render-helpers) to
+send an event to the statechart.
+
+To demonstrate this behavior we'll create a `CounterMachine` that implements
+counting behavior. The component that uses it will be passed a `count`-arg.
+Whenever this arg changes we want to react to the change:
+
+We can react to the change in two ways.
+
+1) We send an event to the statechart on `update` and the statechart reacts to
+the change as it would to any other external or internal event - in our case
+this means we reset `context.count` to the count-arg we receive in the update:
+
+<DocsDemo as |demo|>
+  <demo.example>
+    {{!-- BEGIN-SNIPPET counter.md --}}
+    <Counter @count={{this.counterCount}} />
+    <div class="docs-flex docs-justify-end docs-mt-12">
+      <input
+        value={{this.count}}
+        class="docs-border-2 docs-p-1 docs-rounded-sm docs-mr-2"
+        {{on "input" this.updateCount}}
+      >
+      <UiButton
+        {{on "click" this.syncCounterCount}}
+      >
+        Update Counter-Count
+      </UiButton>
+    </div>
+    {{!-- END-SNIPPET --}}
+  </demo.example>
+  <demo.snippet @name="counter-update-event.js" @label="components.js" />
+  <demo.snippet @name="counter-machine.js" @label="counter-machine" />
+  <demo.snippet @name="counter.md" @label="template.hbs" />
+</DocsDemo>
+
+2) We restart the entire underlying [xstate-interpreter](https://xstate.js.org/docs/guides/interpretation.html) and end up with a statechart as if we accessed if for the first
+time with the update `machine`, `context` or `config`. In our case this means
+that we will end up in the `inactive`-state again even if we were in the
+`active` state before.
+
+<DocsDemo as |demo|>
+  <demo.example @name='counter-restart.md'>
+    <CounterRestart @count={{this.counterCount}} />
+    <div class="docs-flex docs-justify-end docs-mt-12">
+      <input
+        value={{this.count}}
+        class="docs-border-2 docs-p-1 docs-rounded-sm docs-mr-2"
+        {{on "input" this.updateCount}}
+      >
+      <UiButton
+        {{on "click" this.syncCounterCount}}
+      >
+        Update Counter-Count
+      </UiButton>
+    </div>
+  </demo.example>
+
+  <demo.snippet @name="counter-update-restart.js" @label="components.js" />
+  <demo.snippet @name="counter-machine.js" @label="counter-machine" />
+  <demo.snippet @name="counter-restart.md" @label="template.hbs" />
+</DocsDemo>
+
+How you choose handle an update to args/state passed to `useMachine` - either
+sending an event or restarting the interpreter - depends on the situation you
+find yourself in. If your situation allows throwing away the current state of
+the statechart restarting could be an option to consider. If you need to
+consider the current state when args change you will most likely find it easier
+to send an event to the statechart instead of restarting the entire
+interpreter.
+
 ## Legacy api
 
 `ember-statecharts` still ships with the legacy `computed`-macro api. If you


### PR DESCRIPTION
fixes #268 

This PR adds functionality to react to args/state-updates that are used in the `useMachine`-usable.

When args or state passed to `useMachine`, `withContext` or `withConfig` change users should be able to react to the change without needing to use `render-modifiers` or similar functionalty to send an event to the statechart.

To demonstrate the new behavior we start out by defining a machine that increments a counter:

```js
// app/machines/counter-machine.js

import { Machine, assign } from 'xstate';

export default Machine({
  id: 'counterMachine',
  initial: 'inactive',
   context: {
      count: 0
  },
  on: {
    RESET_COUNT: {
        actions: [
          assign({
            count: (_context, { count }) => count
          })
        ]
      }
  },
  states: {
    inactive: {
      on: {
        ACTIVATE: 'active'
      }
    },
    active: {
      on: {
        DEACTIVATE: 'inactive',
        INCREMENT: {
          target: 'active',
          actions: [
            assign({
              count: (context) => context.count + 1
            })
          ]
        },
      }
    }
  }
})
```

The `.update`-hook for `useMachine` makes it easy to react to state changes that are triggered by a setup similar to this:

```js
  // we want to be able to react to a change to `this.args.count`
  @use statechart = useMachine(counterMachine)
    .withContext({
      count: this.args.count
    })
```

There are two ways for users to react to a state change via the `.update`-hook now:

* send an event to the statechart directly
* restart the underlying xstate interpreter

1) Send an event to the interpreter to handle this behavior via a statechart transition by using the `send`-function accessible in `update`.

Example:

```js
export default CounterComponent extends Component {
  @use statechart = useMachine(counterMachine)
    .withContext({
      count: this.args.count
    })
    .update(({ send, context }) => send('RESET_COUNT', { count: context.count });
    
}
```

This means that whenever `args.count` - changes the statechart will be sent the `RESET_COUNT` event - in this scenario the statechart models the behavior that should be triggered explicitly and users can react to an args change with the full power of xstate.  

2) Restart the underlying xstate-interpreter - in some scenarios user might want to restart the entire interpreter when args/state changes. This is possible with the `restart` function accessible in `update`.

Example:

```js
export default CounterComponent extends Component {
  @use statechart = useMachine(counterMachine)
    .withContext({
      count: this.args.count
    })
    .update(({ restart }) => restart());
    
}
```
`restart` will teardown the existing interpreter and start a new one with the update configuration in its place. In our example this would mean that the statechart ends up in the `inactive` state again if it was in `active` before.

## `.update`
The `.update`-hook to `useMachine` will be triggered whenever any args or state passed to `useMachine`, `withContext` or `withConfig` - change. The function gets passed an object with the following structure:

```
send: Function - a function to send an event to the statechart
restart:  Function - a function to teardown the old and restart the a new interpreter with the new configuration
machine: The object passed to `useMachine`
context: the object passed to `withContext`
config: the object passed to `withConfig`
```
