### PR TITLE
Feature: start with state & onTransition

### DIFF
--- a/addon/usables/use-machine.js
+++ b/addon/usables/use-machine.js
@@ -13,9 +13,10 @@ export class InterpreterService {
   @tracked service;
   @tracked _state;
 
-  constructor(machine, interpreterOptions) {
+  constructor(machine, interpreterOptions, onTransition) {
     this.machine = machine;
     this.interpreterOptions = interpreterOptions || {};
+    this.onTransition = onTransition;
   }
 
   get state() {
@@ -44,6 +45,10 @@ export class InterpreterService {
       this._state = state;
     });
 
+    if (this.onTransition) {
+      this.service.onTransition(this.onTransition);
+    }
+
     this.service.start(setupOptions.initialState || state);
   }
 
@@ -53,10 +58,16 @@ export class InterpreterService {
 }
 
 export class MachineInterpreterManager {
-  createUsable(context, { machine, interpreterOptions }) {
+  createUsable(context, { machine, interpreterOptions, _onTransition }) {
     const owner = getOwner(context);
 
-    const interpreter = new InterpreterService(machine, interpreterOptions);
+    let onTransition;
+
+    if (_onTransition) {
+      onTransition = _onTransition.bind(context);
+    }
+
+    const interpreter = new InterpreterService(machine, interpreterOptions, onTransition);
 
     setOwner(interpreter, owner);
 
@@ -122,6 +133,11 @@ export default function useMachine(machine, interpreterOptions = {}) {
 
   configurableMachineDefinition.update = function (fn) {
     configurableMachineDefinition._update = fn;
+    return configurableMachineDefinition;
+  };
+
+  configurableMachineDefinition.onTransition = function (fn) {
+    configurableMachineDefinition._onTransition = fn;
     return configurableMachineDefinition;
   };
 

--- a/addon/usables/use-machine.js
+++ b/addon/usables/use-machine.js
@@ -26,7 +26,9 @@ export class InterpreterService {
     };
   }
 
-  setup() {
+  setup(setupOptions = {}) {
+    const { state } = this.interpreterOptions;
+
     this.service = interpret(this.machine, {
       devTools: DEBUG,
       ...this.interpreterOptions,
@@ -38,11 +40,11 @@ export class InterpreterService {
           return cancel.call(null, timer);
         },
       },
-    })
-      .onTransition((state) => {
-        this._state = state;
-      })
-      .start();
+    }).onTransition((state) => {
+      this._state = state;
+    });
+
+    this.service.start(setupOptions.initialState || state);
   }
 
   teardown() {
@@ -65,8 +67,8 @@ export class MachineInterpreterManager {
     return interpreter.state;
   }
 
-  setupUsable({ interpreter }) {
-    interpreter.setup();
+  setupUsable({ interpreter, setupOptions }) {
+    interpreter.setup(setupOptions);
   }
 
   updateUsable(bucket, configurableMachineDefinition) {
@@ -92,9 +94,10 @@ export class MachineInterpreterManager {
     interpreter.teardown();
   }
 
-  restartUsable(bucket, configurableMachineDefinition) {
+  restartUsable(bucket, configurableMachineDefinition, state) {
     this.teardownUsable(bucket);
     bucket.interpreter = this.createUsable(bucket, configurableMachineDefinition).interpreter;
+    bucket.setupOptions = { initialState: state };
     this.setupUsable(bucket);
   }
 }


### PR DESCRIPTION
This PR adds the following new functionality:

1) `useMachine` now allows the `state`-param to be passed as an interpreter option. This aligns ember-statecharts' `useMachine` with xstate's [interpreter.start](https://xstate.js.org/docs/guides/states.html#persisting-state) and [xstate/react's useMachine](https://github.com/davidkpiano/xstate/tree/master/packages/xstate-react#usemachinemachine-options) and enables users to start an interpreter in a specified state.
2) The `update`-hook's `restart` functionality now also allows passing of a state that the new interpreter will be started in
3) This PR adds a new `onTransition` hook that will fire whenever the underlying interpreter transitions into a new state - this can be useful to persist the statechart's state or for instrumentation purposes like logging.

@pangratz this was easier to add than I expected - happy to pair further for fine tuning