### PR TITLE
Fix docs syntax error

### DIFF
--- a/tests/dummy/app/templates/docs/statecharts.md
+++ b/tests/dummy/app/templates/docs/statecharts.md
@@ -236,10 +236,12 @@ export default class MyComponent extends Component {
       component: this
     })
     .withConfig({
-      handleSubmit(context) {
-        const { component } = context;
+      actions: {
+        handleSubmit(context) {
+          const { component } = context;
 
-        component.buttonClickedTask.perform();
+          component.buttonClickedTask.perform();
+        }
       }
     })
 


### PR DESCRIPTION
Maybe I'm reading it wrong, but I believe that without the `actions` wrapper, this piece of code won't work.