### PR TITLE
fix: onEntry -> entry; onExit -> exit

### DIFF
--- a/tests/dummy/app/controllers/docs/tutorial.js
+++ b/tests/dummy/app/controllers/docs/tutorial.js
@@ -41,7 +41,7 @@ export default Controller.extend({
           },
         },
         busy: {
-          onEntry: ['handleSubmit'],
+          entry: ['handleSubmit'],
         },
       },
     },
@@ -63,7 +63,7 @@ export default Controller.extend({
           },
         },
         busy: {
-          onEntry: ['handleSubmit'],
+          entry: ['handleSubmit'],
           on: {
             SUCCESS: 'success',
           },
@@ -89,7 +89,7 @@ export default Controller.extend({
           },
         },
         busy: {
-          onEntry: ['handleSubmit'],
+          entry: ['handleSubmit'],
           on: {
             SUCCESS: 'success',
             ERROR: 'error',
@@ -117,17 +117,17 @@ export default Controller.extend({
           },
         },
         busy: {
-          onEntry: ['handleSubmit'],
+          entry: ['handleSubmit'],
           on: {
             SUCCESS: 'success',
             ERROR: 'error',
           },
         },
         success: {
-          onEntry: ['handleSuccess'],
+          entry: ['handleSuccess'],
         },
         error: {
-          onEntry: ['handleError'],
+          entry: ['handleError'],
         },
       },
     },
@@ -151,20 +151,20 @@ export default Controller.extend({
           },
         },
         busy: {
-          onEntry: ['handleSubmit'],
+          entry: ['handleSubmit'],
           on: {
             SUCCESS: 'success',
             ERROR: 'error',
           },
         },
         success: {
-          onEntry: ['handleSuccess'],
+          entry: ['handleSuccess'],
           on: {
             SUBMIT: 'busy',
           },
         },
         error: {
-          onEntry: ['handleError'],
+          entry: ['handleError'],
           on: {
             SUBMIT: 'busy',
           },
@@ -218,14 +218,14 @@ export default Controller.extend({
               },
             },
             busy: {
-              onEntry: ['handleSubmit'],
+              entry: ['handleSubmit'],
               on: {
                 SUCCESS: 'success',
                 ERROR: 'error',
               },
             },
             success: {
-              onEntry: ['handleSuccess'],
+              entry: ['handleSuccess'],
               on: {
                 SUBMIT: {
                   target: 'busy',
@@ -234,7 +234,7 @@ export default Controller.extend({
               },
             },
             error: {
-              onEntry: ['handleError'],
+              entry: ['handleError'],
               on: {
                 SUBMIT: {
                   target: 'busy',

--- a/tests/dummy/app/controllers/editor.js
+++ b/tests/dummy/app/controllers/editor.js
@@ -14,20 +14,20 @@ export default Controller.extend({
       },
     },
     busy: {
-      onEntry: ['handleSubmit'],
+      entry: ['handleSubmit'],
       on: {
         SUCCESS: 'success',
         ERROR: 'error',
       },
     },
     success: {
-      onEntry: ['handleSuccess'],
+      entry: ['handleSuccess'],
       on: {
         SUBMIT: 'busy',
       },
     },
     error: {
-      onEntry: ['handleError'],
+      entry: ['handleError'],
       on: {
         SUBMIT: 'busy',
       },

--- a/tests/dummy/app/templates/docs/statecharts.md
+++ b/tests/dummy/app/templates/docs/statecharts.md
@@ -211,7 +211,7 @@ const buttonMachine = Machine(
         }
       },
       busy: {
-        onEntry: ['handleSubmit'],
+        entry: ['handleSubmit'],
         on: {
           RESOLVE: 'success',
           REJECT: 'error'
@@ -286,7 +286,7 @@ const buttonMachine = Machine({
       }
     },
     busy: {
-      onEntry: ['handleSubmit'],
+      entry: ['handleSubmit'],
       on: {
         RESOLVE: 'success',
         REJECT: 'error'
@@ -349,7 +349,7 @@ const submitMachine = Machine({
       }
     },
     busy: {
-      onEntry: ['handleSubmit'],
+      entry: ['handleSubmit'],
       on: {
         RESOLVE: 'success',
         REJECT: 'error'
@@ -426,7 +426,7 @@ const submitMachine = Machine({
       }
     },
     busy: {
-      onEntry: ['handleSubmit'],
+      entry: ['handleSubmit'],
       on: {
         RESOLVE: 'success',
         REJECT: 'error'
@@ -499,7 +499,7 @@ export default class MyComponent extends Component {
         }
       },
       busy: {
-        onEntry: ['handleSubmit'],
+        entry: ['handleSubmit'],
         on: {
           RESOLVE: 'success',
           REJECT: 'error'

--- a/tests/unit/statechart-test.js
+++ b/tests/unit/statechart-test.js
@@ -14,7 +14,7 @@ module('Unit | computed | statechart', function () {
           initial: 'new',
           states: {
             new: {
-              onExit() {
+              exit() {
                 assert.ok(true, 'exitState was called');
               },
               on: {
@@ -25,7 +25,7 @@ module('Unit | computed | statechart', function () {
               },
             },
             foo: {
-              onEntry(_context, { type, ...data }) {
+              entry(_context, { type, ...data }) {
                 assert.deepEqual(data, testData, 'passed data is available in eventObject');
               },
             },
@@ -116,7 +116,7 @@ module('Unit | computed | statechart', function () {
           initial: 'powerOff',
           states: {
             powerOff: {
-              onEntry: ['incrementOffCounter'],
+              entry: ['incrementOffCounter'],
               on: {
                 POWER: 'powerOn',
               },

--- a/tests/unit/utils/statechart-test.js
+++ b/tests/unit/utils/statechart-test.js
@@ -253,7 +253,7 @@ module('Unit | Utility | statechart', function (/*hooks*/) {
       assert.equal(statechart.currentState.value, 'new');
     });
 
-    test("when a new state is entered the old state's `onExit` function will be called and after that the newState's `onEntry` function`", async function (assert) {
+    test("when a new state is entered the old state's `exit` function will be called and after that the newState's `entry` function`", async function (assert) {
       let someData = { woot: 'lol' };
 
       let statechart = new Statechart({
@@ -263,13 +263,13 @@ module('Unit | Utility | statechart', function (/*hooks*/) {
             on: {
               woot: 'next',
             },
-            onExit(_context, { type, ...data }) {
+            exit(_context, { type, ...data }) {
               assert.step('exitState');
               assert.deepEqual(data, someData, 'states can pass data when they transition');
             },
           },
           next: {
-            onEntry(context, { type, ...data }) {
+            entry(context, { type, ...data }) {
               assert.step('enterState');
               assert.deepEqual(data, someData, 'states can pass data when they transition');
             },
@@ -582,10 +582,10 @@ module('Unit | Utility | statechart', function (/*hooks*/) {
               initial: 'stopped',
               states: {
                 stopped: {
-                  onEntry(context) {
+                  entry(context) {
                     assert.deepEqual(context, testContext, 'context is available as expected');
                   },
-                  onExit(context) {
+                  exit(context) {
                     assert.equal(context.name, 'lol');
                   },
                   on: {
@@ -631,7 +631,7 @@ module('Unit | Utility | statechart', function (/*hooks*/) {
       assert.equal(statechart.currentState.value, 'off');
     });
 
-    test('nested statecharts will execute onEntry handlers for the chart first and then for the initial state of the nested chart', async function (assert) {
+    test('nested statecharts will execute entry handlers for the chart first and then for the initial state of the nested chart', async function (assert) {
       let testData = {
         wat: 'lol',
       };
@@ -649,7 +649,7 @@ module('Unit | Utility | statechart', function (/*hooks*/) {
             initial: 'stopped',
             states: {
               stopped: {
-                onEntry(context, { type, ...data }) {
+                entry(context, { type, ...data }) {
                   assert.deepEqual(
                     data,
                     testData,
@@ -659,12 +659,12 @@ module('Unit | Utility | statechart', function (/*hooks*/) {
                 },
               },
               playing: {
-                onEntry() {
+                entry() {
                   assert.step('wat');
                 },
               },
             },
-            onEntry(context, { type, ...data }) {
+            entry(context, { type, ...data }) {
               assert.deepEqual(
                 data,
                 testData,
@@ -694,17 +694,17 @@ module('Unit | Utility | statechart', function (/*hooks*/) {
             initial: 'stopped',
             states: {
               stopped: {
-                onExit() {
+                exit() {
                   assert.step('stopped');
                 },
               },
               playing: {
-                onExit() {
+                exit() {
                   assert.step('wat');
                 },
               },
             },
-            onExit() {
+            exit() {
               assert.step('on');
             },
             on: {
@@ -866,7 +866,7 @@ module('Unit | Utility | statechart', function (/*hooks*/) {
                   },
                 },
                 pending: {
-                  onEntry(context, { type, ...data }) {
+                  entry(context, { type, ...data }) {
                     assert.deepEqual(data, testData, 'passing data works');
                     assert.deepEqual(context, testContext, 'context is passed as expected');
                   },


### PR DESCRIPTION
I _think_ that [the correct way](https://xstate.js.org/docs/guides/actions.html#declarative-actions) to set up entry/exit actions is via `entry` resp. `exit` keys. Not `onEntry` / `onExit` like the documentation / code says.