### PR TITLE
Point ember-usable at the new github URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "ember-cli-babel": "^7.23.0",
     "ember-cli-htmlbars": "^5.3.1",
     "ember-cli-typescript": "^3.1.4",
-    "ember-usable": "https://github.com/pzuraq/ember-could-get-used-to-this#0d03a50",
+    "ember-usable": "https://github.com/pzuraq/ember-could-get-used-to-this#0d03a500a2f49041a4ddff0bb05b077c3907ed7d",
     "xstate": "^4.12.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "ember-cli-babel": "^7.23.0",
     "ember-cli-htmlbars": "^5.3.1",
     "ember-cli-typescript": "^3.1.4",
-    "ember-usable": "https://github.com/pzuraq/ember-usable#0d03a50",
+    "ember-usable": "https://github.com/pzuraq/ember-could-get-used-to-this#0d03a50",
     "xstate": "^4.12.0"
   },
   "devDependencies": {


### PR DESCRIPTION
I know #317 is still in the works, but in the meantime I was experimenting with using yarn v2/berry in one of my ember apps and it did not want to resolve the dependencies as they are.

By tweaking the URL to the new one, and using the full commit hash, I was able to get it to work and from my testing this seems to work fine with yarn v1 and v2.