### PR TITLE
Deploy versioned docs

### DIFF
--- a/packages/site/app/components/api-toc.hbs
+++ b/packages/site/app/components/api-toc.hbs
@@ -1,7 +1,7 @@
 <ul class='list-inside text-sm' ...attributes>
   <li class='font-medium'>
     <a
-      href='/api-docs/index.html'
+      href='{{this.rootURL}}api-docs/index.html'
       target='_blank'
       rel='noopener noreferrer'
       class='flex items-center pb-2 hover:text-ember'
@@ -25,7 +25,7 @@
   </li>
   <li class='font-mono text-xs'>
     <a
-      href='/api-docs/modules/usables_use_machine.html#default'
+      href='{{this.rootURL}}api-docs/modules/usables_use_machine.html#default'
       target='_blank'
       rel='noopener noreferrer'
       class='block px-2 pb-2 border-l-2 hover:text-ember'
@@ -35,7 +35,7 @@
   </li>
   <li class='font-mono text-xs'>
     <a
-      href='/api-docs/modules/index.html#matchesstate'
+      href='{{this.rootURL}}api-docs/modules/index.html#matchesstate'
       target='_blank'
       rel='noopener noreferrer'
       class='block px-2 pb-2 border-l-2 hover:text-ember'
@@ -45,7 +45,7 @@
   </li>
   <li class='font-mono text-xs'>
     <a
-      href='/api-docs/modules/index.html#interpreterfor'
+      href='{{this.rootURL}}api-docs/modules/index.html#interpreterfor'
       target='_blank'
       rel='noopener noreferrer'
       class='block px-2 pb-2 border-l-2 hover:text-ember'

--- a/packages/site/app/components/api-toc.js
+++ b/packages/site/app/components/api-toc.js
@@ -1,0 +1,8 @@
+import Component from '@glimmer/component';
+import config from 'site/config/environment';
+
+export default class ApiTocComponent extends Component {
+  get rootUrl() {
+    return config.rootURL;
+  }
+}

--- a/packages/site/config/environment.js
+++ b/packages/site/config/environment.js
@@ -46,6 +46,11 @@ module.exports = function (environment) {
     ],
   };
 
+  if (process.env.DEPLOY_TARGET) {
+    const versionedDocInfo = require('../lib/versioned-doc-info');
+    ENV.rootURL = versionedDocInfo(process.env.DEPLOY_TARGET).rootURL;
+  }
+
   if (environment === 'development') {
     // ENV.APP.LOG_RESOLVER = true;
     // ENV.APP.LOG_ACTIVE_GENERATION = true;

--- a/packages/site/lib/deploy-versioned-doc/index.js
+++ b/packages/site/lib/deploy-versioned-doc/index.js
@@ -1,0 +1,82 @@
+/* eslint-env node */
+'use strict';
+
+const versionedDocInfo = require('../versioned-doc-info');
+const path = require('path');
+const fs = require('fs-extra');
+const os = require('os');
+
+module.exports = {
+  name: require('./package').name,
+
+  createDeployPlugin: function (options) {
+    return {
+      name: options.name,
+
+      async willUpload(context) {
+        const {
+          deployTarget,
+          distDir,
+          gitDeploy: { worktreePath },
+        } = context;
+
+        const { name, destDir, rootURL, sha, tag } = versionedDocInfo(
+          deployTarget
+        );
+
+        // cache current build
+        let currentBuild = path.join(os.tmpdir(), 'current-build-');
+        fs.moveSync(distDir, currentBuild);
+
+        // ensure we have a ${worktree}/versions/
+        let versions = path.resolve(worktreePath, 'versions');
+        fs.ensureDirSync(versions);
+
+        if (deployTarget === 'latest') {
+          // keep the current versions
+          fs.copySync(versions, path.resolve(currentBuild, 'versions'));
+
+          // make current build the new dist
+          fs.moveSync(currentBuild, distDir);
+        } else {
+          // keep current state of gh-pages
+          fs.copySync(worktreePath, distDir);
+
+          // move current build into versions/${branch || tag}
+          fs.moveSync(currentBuild, path.resolve(distDir, destDir), {
+            overwrite: true,
+          });
+        }
+
+        // get ${worktree}/versions.json
+        let versionsJSON = {};
+        let versionsFile = path.resolve(worktreePath, 'versions.json');
+        if (fs.existsSync(versionsFile)) {
+          versionsJSON = fs.readJsonSync(versionsFile);
+        }
+
+        let key = name;
+
+        // update key for latest, this is for ember-cli-addon-docs compatibility
+        if (deployTarget === 'latest') {
+          key = '-latest';
+        }
+
+        versionsJSON[key] = {
+          path: rootURL,
+          name,
+          sha,
+          tag,
+        };
+
+        // write current versions.json
+        fs.writeFileSync(
+          path.resolve(distDir, 'versions.json'),
+          JSON.stringify(versionsJSON, null, 2)
+        );
+
+        fs.removeSync(currentBuild);
+      },
+    };
+  },
+};

--- a/packages/site/lib/deploy-versioned-doc/package.json
+++ b/packages/site/lib/deploy-versioned-doc/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "deploy-versioned-doc",
+  "keywords": [
+    "ember-addon",
+    "ember-cli-deploy-plugin"
+  ]
+}

--- a/packages/site/lib/versioned-doc-info.js
+++ b/packages/site/lib/versioned-doc-info.js
@@ -1,0 +1,42 @@
+/* eslint-env node */
+'use strict';
+
+const getRepoInfo = require('git-repo-info');
+
+module.exports = function (deployTarget) {
+  let dir, name, rootURL;
+  let { sha, tag, branch } = getRepoInfo();
+
+  if (deployTarget === 'tag') {
+    dir = tag;
+    name = tag;
+    branch = null;
+  } else if (deployTarget === 'branch') {
+    dir = branch;
+    name = branch;
+    tag = null;
+  } else if (deployTarget === 'latest') {
+    dir = 'latest';
+    name = 'Latest';
+  } else {
+    throw new Error(`unsupported deploy target ${deployTarget}`);
+  }
+
+  let destDir = `versions/${dir}`;
+
+  if (deployTarget === 'latest') {
+    rootURL = '/';
+  } else {
+    rootURL = `/${destDir}/`;
+  }
+
+  return {
+    name,
+    sha,
+    tag,
+    branch,
+    destDir,
+    rootURL,
+    deployTarget,
+  };
+};

--- a/packages/site/package.json
+++ b/packages/site/package.json
@@ -111,5 +111,10 @@
   },
   "ember": {
     "edition": "octane"
+  },
+  "ember-addon": {
+    "paths": [
+      "lib/deploy-versioned-doc"
+    ]
   }
 }

--- a/packages/site/package.json
+++ b/packages/site/package.json
@@ -89,6 +89,7 @@
     "eslint-plugin-ember": "^10.1.1",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^3.3.1",
+    "git-repo-info": "^2.1.1",
     "loader.js": "^4.7.0",
     "npm-run-all": "^4.1.5",
     "postcss-import": "^14.0.2",

--- a/packages/site/package.json
+++ b/packages/site/package.json
@@ -89,6 +89,7 @@
     "eslint-plugin-ember": "^10.1.1",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^3.3.1",
+    "fs-extra": "^9.1.0",
     "git-repo-info": "^2.1.1",
     "loader.js": "^4.7.0",
     "npm-run-all": "^4.1.5",


### PR DESCRIPTION
This brings back the functionality we had with ember-cli-addon-docs: deploy documentation to `versions/_VERSION_` folder within the [gh-pages branch](https://github.com/LevelbossMike/ember-statecharts/tree/gh-pages) (preparation to bring back old versions happening in #376).

The idea is to deploy the `site` package to `versions/v1.2.3` or `versions/master` and update the in #376 brought back `versions.json` accordingly. We can also deploy to the root level of `gh-pages` (by clearing out everything) and copying the fresh build in there as well as the previous state of `versions/` and `versions.json` so we keep the information and content of previous versions of the documentation.

TODO
- [ ] outline how docs can be deployed manually