### PR TITLE
Allow passing `interpreterOptions` to `useMachine`

### DIFF
--- a/.changeset/selfish-humans-hope.md
+++ b/.changeset/selfish-humans-hope.md
@@ -1,0 +1,98 @@
+---
+'ember-statecharts': minor
+---
+
+## 🥁 Features
+
+### InterpreterOptions
+Bring back ability to customize [InterpreterOptions](https://xstate.js.org/docs/guides/interpretation.html#options) that are used when a machine passed to `useMachine` gets interpreted. This is probably most useful for people that want to have xState delays etc. be scheduled via a custom clock service that uses [Ember's runloop](https://guides.emberjs.com/release/applications/run-loop/), but can be used to pass other [interpreterOptions](https://xstate.js.org/docs/guides/interpretation.html#options) as well.
+
+To customize `interpreterOptions`, when you would like to provide the same options every time you use `useMachine`, you can create a wrapper-function for `useMachine`:
+
+Example:
+
+```js
+const wrappedUseMachine = (context, options) => {
+  return useMachine(context, () => {
+    return {
+      interpreterOptions: {
+        clock: {
+          setTimeout(fn, timeout) {
+            later.call(null, fn, timeout);
+          },
+          clearTimeout(id) {
+            cancel.call(null, id);
+          },
+        },
+      },
+      ...options(),
+    };
+  });
+};
+
+statechart = wrappedUseMachine(this, () => {
+  // ...
+});
+```
+
+### `runloopClockService`-configuration option
+For the use-case of having xState timeouts etc. be schedule via the runloop, `ember-statecharts` now provides a configuration option. You can turn it on to have xState use a custom [clock](https://xstate.js.org/docs/guides/delays.html#interpretation) and schedule, and cancel timeouts via the ember-runloop. This makes testing via `@ember/test-helpers` arguably more ergonomic, as you won't need to explicitly await ui changes that are triggered by schedule statechart changes explicitly anymore.
+
+Example - based on the test that tests this behavior:
+
+```js
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'test-app/tests/helpers';
+import { click, render, waitUntil } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | use-machine', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('awaiting needs to be explicit with no `runloopClockService`-option set', async function (assert) {
+    const config = this.owner.resolveRegistration('config:environment');
+
+    config['ember-statecharts'] = {
+      runloopClockService: false,
+    };
+
+    await render(hbs`<DelayedToggle data-test-toggle />`);
+
+    assert.dom('[data-test-off]').exists('initially toggle is off');
+
+    await click('[data-test-toggle]');
+
+    // oh noes, we need to wait explicitly as xState uses `window.setTimeout` by default 😢
+    await waitUntil(() => {
+      return document.querySelector('[data-test-off]');
+    });
+
+    assert.dom('[data-test-off]').exists('initially toggle is off');
+  });
+
+  test('awaiting happens automatically when `runloopClockService`-option is set', async function (assert) {
+    const config = this.owner.resolveRegistration('config:environment');
+
+    config['ember-statecharts'] = {
+      runloopClockService: true,
+    };
+
+    await render(hbs`<DelayedToggle data-test-toggle />`);
+
+    assert.dom('[data-test-off]').exists('initially toggle is off');
+
+    // just awaiting the click is enough now, because we schedule delays on the runloop 🥳
+    await click('[data-test-toggle]');
+
+    assert.dom('[data-test-off]').exists('initially toggle is off');
+  });
+});
+```
+
+To turn on this behavior, you can set the `runloopClockService`-configuration in `config/environment.js`:
+
+```js
+ENV['ember-statecharts'] = {
+  runloopClockService: true
+}
+```

--- a/ember-statecharts/src/resources/statechart.ts
+++ b/ember-statecharts/src/resources/statechart.ts
@@ -23,6 +23,7 @@ import type {
   NoInfer,
   BaseActionObject,
   ServiceMap,
+  InterpreterOptions,
 } from 'xstate';
 
 import type Owner from '@ember/owner';
@@ -104,6 +105,7 @@ interface StatechartArgs<
         >
       >
     ) => void;
+    interpreterOptions?: InterpreterOptions;
   };
 }
 
@@ -226,9 +228,13 @@ export class Statechart<
       >
     >['Named']
   ) {
-    const { machine, initialState, onTransition } = named;
+    const { machine, initialState, onTransition, interpreterOptions } = named;
 
-    const interpreter = interpret(machine).onTransition((state) => {
+    const _interpreterOptions = interpreterOptions || {};
+
+    const interpreter = interpret(machine, {
+      ..._interpreterOptions,
+    }).onTransition((state) => {
       if (state.changed || state.changed === undefined) {
         this.state = state;
       }

--- a/ember-statecharts/src/resources/statechart.ts
+++ b/ember-statecharts/src/resources/statechart.ts
@@ -176,6 +176,7 @@ export class Statechart<
   get config() {
     const owner = getOwner(this);
     if (owner) {
+      // eslint-disable-next-line
       // @ts-ignore
       const config = owner.resolveRegistration('config:environment') as {
         [key: string]: unknown;

--- a/test-apps/test-app/app/components/delayed-toggle.hbs
+++ b/test-apps/test-app/app/components/delayed-toggle.hbs
@@ -1,0 +1,12 @@
+<button
+  type='button'
+  {{on 'click' (fn this.statechart.send 'TOGGLE')}}
+  ...attributes
+>
+  Toggle
+</button>
+{{#if this.isOn}}
+  <div data-test-on>On</div>
+{{else}}
+  <div data-test-off>Off</div>
+{{/if}}

--- a/test-apps/test-app/app/components/delayed-toggle.js
+++ b/test-apps/test-app/app/components/delayed-toggle.js
@@ -1,0 +1,15 @@
+import Component from '@glimmer/component';
+import { useMachine } from 'ember-statecharts';
+import delayedToggle from '../machines/delayed-toggle';
+
+export default class DelayedToggle extends Component {
+  statechart = useMachine(this, () => {
+    return {
+      machine: delayedToggle,
+    };
+  });
+
+  get isOn() {
+    return this.statechart.state.matches('on');
+  }
+}

--- a/test-apps/test-app/app/machines/delayed-toggle.js
+++ b/test-apps/test-app/app/machines/delayed-toggle.js
@@ -1,0 +1,18 @@
+import { createMachine } from 'xstate';
+
+export default createMachine({
+  initial: 'off',
+  states: {
+    off: {
+      on: {
+        TOGGLE: 'on',
+      },
+    },
+    on: {
+      after: {
+        500: 'off',
+      },
+    },
+  },
+  predictableActionArguments: true,
+});

--- a/test-apps/test-app/tests/integration/components/delayed-toggle-test.js
+++ b/test-apps/test-app/tests/integration/components/delayed-toggle-test.js
@@ -1,0 +1,44 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'test-app/tests/helpers';
+import { click, render, waitUntil } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | use-machine', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('awaiting needs to be explicit with no `runloopClockService`-option set', async function (assert) {
+    const config = this.owner.resolveRegistration('config:environment');
+
+    config['ember-statecharts'] = {
+      runloopClockService: false,
+    };
+
+    await render(hbs`<DelayedToggle data-test-toggle />`);
+
+    assert.dom('[data-test-off]').exists('initially toggle is off');
+
+    await click('[data-test-toggle]');
+
+    await waitUntil(() => {
+      return document.querySelector('[data-test-off]');
+    });
+
+    assert.dom('[data-test-off]').exists('initially toggle is off');
+  });
+
+  test('awaiting happens automatically when `runloopClockService`-option is set', async function (assert) {
+    const config = this.owner.resolveRegistration('config:environment');
+
+    config['ember-statecharts'] = {
+      runloopClockService: true,
+    };
+
+    await render(hbs`<DelayedToggle data-test-toggle />`);
+
+    assert.dom('[data-test-off]').exists('initially toggle is off');
+
+    await click('[data-test-toggle]');
+
+    assert.dom('[data-test-off]').exists('initially toggle is off');
+  });
+});


### PR DESCRIPTION
Older versions of ember-statecharts allowed to pass `interpreterOptions` that would be used when an xState interpreter would be started. This commit brings that functionality back.

This is probably most useful for people that want to have xState delays etc. be scheduled via a custom clock service that uses [Ember's runloop](https://guides.emberjs.com/release/applications/run-loop/), but can be used to pass other [interpreterOptions](https://xstate.js.org/docs/guides/interpretation.html#options) as well.